### PR TITLE
Fix broken paths in default configuraiton on Unix

### DIFF
--- a/source/core/gameconfigfile.cpp
+++ b/source/core/gameconfigfile.cpp
@@ -133,7 +133,8 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", "$GAMEDIR", true);
 #else
 		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
-		SetValueForKey ("Path", SHARE_DIR, true);
+		SetValueForKey ("Path", "/usr/share/games/raze", true);
+		SetValueForKey ("Path", "/usr/local/share/games/raze", true);
 		SetValueForKey ("Path", "/usr/share/games/jfduke3d", true);
 		SetValueForKey ("Path", "/usr/local/share/games/jfduke3d", true);
 		SetValueForKey ("Path", "/usr/share/games/eduke32", true);
@@ -156,10 +157,8 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey("Path", "$PROGDIR/soundfonts", true);
 #else
 		SetValueForKey("Path", "$HOME/" GAME_DIR "/soundfonts", true);
-		SetValueForKey("Path", "/usr/local/share/" GAME_DIR "/soundfonts", true);
-		SetValueForKey("Path", "/usr/local/share/games/" GAME_DIR "/soundfonts", true);
-		SetValueForKey("Path", "/usr/share/" GAME_DIR "/soundfonts", true);
-		SetValueForKey("Path", "/usr/share/games/" GAME_DIR "/soundfonts", true);
+		SetValueForKey("Path", "/usr/share/games/raze/soundfonts", true);
+		SetValueForKey("Path", "/usr/local/share/games/raze/soundfonts", true);
 #endif
 	}
 


### PR DESCRIPTION
The default paths for **FileSearch.Directories** and **SoundfontSearch.Directories** are somewhat broken.

`SHARE_DIR` is defined as just `/usr/local/share/`.
The paths `…/games/raze` are not added to **FileSearch.Directories**.
`GAME_DIR` is defined as `.config/raze` on Unix. Combining it with the prefix `…/share/` is wrong.

Excerpt from the default configuration:

```ini
[FileSearch.Directories]
…
Path=/usr/local/share/
…

[SoundfontSearch.Directories]
…
Path=/usr/local/share/.config/raze/soundfonts
Path=/usr/local/share/games/.config/raze/soundfonts
Path=/usr/share/.config/raze/soundfonts
Path=/usr/share/games/.config/raze/soundfonts
```