### PR TITLE
Add Linux Appimage Build Workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,53 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build-appimage:
+    name: Linux Clang 12 | AppImage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Raze dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-12 libsdl2-dev libvpx-dev cmake -y
+      - name: Install appimage-builder dependencies
+        run: |
+          sudo apt-get install binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf -y 
+          sudo apt-get install python3-pip python3-setuptools squashfs-tools strace util-linux zsync -y 
+          sudo apt-get install imagemagick-6.q16hdri -y
+      - name: Install appimage-builder
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install appimage-builder
+      - name: Build zmusic dependency
+        run: |
+          git clone -b 1.1.11 https://github.com/ZDoom/ZMusic.git zmusic_build
+          mkdir ./zmusic_build/build
+          cd ./zmusic_build/build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build .
+          cd ../../
+          mkdir -p ./AppDir/zmusic/lib
+          mkdir ./AppDir/zmusic/include
+          mv ./zmusic_build/build/source/libzmusic* ./AppDir/zmusic/lib/
+          mv ./zmusic_build/include/zmusic.h ./AppDir/zmusic/include/
+      - name: Configure
+        run: cmake -B AppDir -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH=`pwd`/AppDir/zmusic -DPK3_QUIET_ZIPDIR=ON -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12 .
+      - name: Build
+        shell: bash
+        run: |
+          export MAKEFLAGS=--keep-going
+          cmake --build AppDir --config Release --parallel `nproc`
+          cp ./AppDir/zmusic/lib/* ./AppDir/
+          mkdir -p ./AppDir/usr/share/icons
+          convert ./source/platform/win32/game_icon.ico[0] -flatten ./AppDir/usr/share/icons/game_icon.png
+      - name: Build AppImage
+        run: |
+          appimage-builder --skip-tests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: AppImage
+          path: './*.AppImage*'

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ build-vs2019/
 /source/gitinfo.h
 /build2
 /build
+/AppDir
+/appimage-build
+*.AppImage
 .DS_Store

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,45 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: com.Raze.app
+    name: Raze
+    icon: game_icon.png
+    version: latest
+    exec: ./raze
+    exec_args: $@
+  apt:
+    arch: amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ jammy main restricted
+    - sourceline: deb http://us.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
+    include: []
+  files:
+    include: []
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+  test:
+    fedora-30:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+    debian-stable:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+    archlinux-latest:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+    centos-7:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+    ubuntu-xenial:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+AppImage:
+  arch: x86_64
+  update-information: guess


### PR DESCRIPTION
I believe this is good enough to look at for a PR, refer to #678 I imagine there might be some things I'm not quite doing right with Raze itself. I've only tested it against running Duke Nukem 3d 

I tested this locally using [nektos/act](https://github.com/nektos/act) and on github actions directly,
https://github.com/fang64/Raze/actions/runs/3784997258

I've generated a appimage binary that is working under Ubuntu 22.04 LTS and on Arch, it seems to run fine under Wayland and Xorg.

Built AppImage: https://github.com/fang64/Raze/suites/10065608383/artifacts/490030840

 