### PR TITLE
Impel people to include saved games in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -84,7 +84,7 @@ body:
     id: description
     attributes:
       label: A clear and concise description of what the bug is.
-      description: Describe what happens, what software were you running? _Include screenshot if possible_
+      description: Describe what happens, what software were you running? _Include a saved game demonstrating the bug, or a screenshot if possible_
       placeholder: "How & When does this occur?"
     validations:
       required: true


### PR DESCRIPTION
Since saved games are the preferred way for Raze developers to reproduce bugs.