### PR TITLE
Keycards need the noskill flag

### DIFF
--- a/wadsrc/static/filter/dukelike/rmapinfo.spawnclasses
+++ b/wadsrc/static/filter/dukelike/rmapinfo.spawnclasses
@@ -283,7 +283,7 @@ spawnclasses
 	48 = DukeAmmoLots
 	51 = DukeCola
 	53 = DukeFirstAid
-	60 = DukeAccessCard
+	60 = DukeAccessCard, noskill
 	
 	41 = DukeBatteryAmmo
 	52 = DukeSixpak


### PR DESCRIPTION
Otherwise, maps like E2L2 will have missing keycards