### PR TITLE
Fix a memory write issue with plasma_{A,B,C}

### DIFF
--- a/source/games/exhumed/src/2d.cpp
+++ b/source/games/exhumed/src/2d.cpp
@@ -107,9 +107,9 @@ void menu_DoPlasma()
     {
         nPlasmaTile = TexMan.GetGameTexture(aTexIds[kTexPlasmaTile1]);
         nPlasmaTileAlt = TexMan.GetGameTexture(aTexIds[kTexPlasmaTile2]);
-        plasma_A[5] = {};
-        plasma_B[5] = {};
-        plasma_C[5] = {};
+        memset(plasma_A, 0, sizeof(plasma_A));
+        memset(plasma_B, 0, sizeof(plasma_B));
+        memset(plasma_C, 0, sizeof(plasma_C));
     }
 
     const auto nLogoTexid = GameLogo();


### PR DESCRIPTION
`plasma_A[5] = {};` will write the default value for int to the sixth element of plasma_A, causing a `global-buffer-overflow`.

I assume the intention here was to fill these three arrays with zeroes, which is what I did with the memset calls.