### PR TITLE
Add crash log file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build-vs2019/
 /appimage-build
 *.AppImage
 .DS_Store
+raze-crash.log


### PR DESCRIPTION
- Raze counterpart of https://github.com/ZDoom/gzdoom/pull/2496.

This prevents accidentally committing this file if you run into a crash while working on something.
