### PR TITLE
Fix all horizontal movement being broken

### DIFF
--- a/source/common/utility/vectors.h
+++ b/source/common/utility/vectors.h
@@ -94,6 +94,8 @@ struct TVector2
 	{
 	}
 
+	constexpr TVector2(std::nullptr_t nul) = delete;
+
 	template<typename U>
 	constexpr explicit operator TVector2<U> () const noexcept {
 		return TVector2<U>(static_cast<U>(X), static_cast<U>(Y));

--- a/source/common/utility/vectors.h
+++ b/source/common/utility/vectors.h
@@ -544,6 +544,12 @@ struct TVector3
 		return Vector2(X, Y);
 	}
 
+	void SetXY(const Vector2 &v)
+	{
+		X = v.X;
+		Y = v.Y;
+	}
+
 	// Add a 3D vector and a 2D vector.
 	constexpr friend TVector3 operator+ (const TVector3 &v3, const Vector2 &v2)
 	{

--- a/source/core/coreactor.h
+++ b/source/core/coreactor.h
@@ -111,7 +111,7 @@ public:
 
 	void backupvec2()
 	{
-		opos.XY() = spr.pos.XY();
+		opos.SetXY(spr.pos.XY());
 	}
 
 	void backuppos()
@@ -139,7 +139,7 @@ public:
 
 	void restorevec2()
 	{
-		spr.pos.XY() = opos.XY();
+		spr.pos.SetXY(opos.XY());
 	}
 
 	void restorepos()

--- a/source/core/coreplayer.h
+++ b/source/core/coreplayer.h
@@ -42,7 +42,7 @@ public:
 	virtual bool canSlopeTilt() const { return false; }
 	virtual unsigned getCrouchFlags() const = 0;
 	virtual double GetMaxInputVel() const = 0;
-	virtual const DVector2& GetInputVelocity() const { return actor->vel.XY(); }
+	virtual const DVector2 GetInputVelocity() const { return actor->vel.XY(); }
 
 	// Angle prototypes.
 	void doPitchInput();

--- a/source/core/gamefuncs.cpp
+++ b/source/core/gamefuncs.cpp
@@ -693,8 +693,8 @@ double checkSectorPlaneHit(sectortype* sec, const DVector3& start, const DVector
 	double startcz, startfz;
 	double p3cz, p3fz;
 
-	pt1.XY() = wal->pos;
-	pt2.XY() = wal->point2Wall()->pos;
+	pt1.SetXY(wal->pos);
+	pt2.SetXY(wal->point2Wall()->pos);
 	pt3.X = pt1.X + pt2.Y - pt1.Y;
 	pt3.Y = pt1.Y + pt2.X - pt1.X; // somewhere off the first line.
 

--- a/source/core/rendering/scene/hw_drawinfo.cpp
+++ b/source/core/rendering/scene/hw_drawinfo.cpp
@@ -316,11 +316,11 @@ void HWDrawInfo::DispatchSprites()
 
 		if (actor->sprext.renderflags & SPREXT_AWAY1)
 		{
-			tspr->pos.XY() += tspr->Angles.Yaw.ToVector() * 0.125;
+			tspr->pos += tspr->Angles.Yaw.ToVector() * 0.125;
 		}
 		else if (actor->sprext.renderflags & SPREXT_AWAY2)
 		{
-			tspr->pos.XY() -= tspr->Angles.Yaw.ToVector() * 0.125;
+			tspr->pos -= tspr->Angles.Yaw.ToVector() * 0.125;
 		}
 
 		switch (tspr->cstat & CSTAT_SPRITE_ALIGNMENT_MASK)

--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -2936,7 +2936,7 @@ static bool actKillModernDude(DBloodActor* actor, DAMAGE_TYPE damageType)
 			actDropObject(actor, actor->xspr.dropMsg);
 
 		actor->spr.flags &= ~kPhysMove;
-		actor->vel.XY().Zero();
+		actor->vel.SetXY(DVector2(0, 0));
 
 		playGenDudeSound(actor, kGenDudeSndTransforming);
 		int seqId = actor->xspr.data2 + kGenDudeSeqTransform;
@@ -4137,7 +4137,7 @@ static void checkCeilHit(DBloodActor* actor)
 			if ((actor2->spr.statnum == kStatThing || actor2->spr.statnum == kStatDude) && !actor->vel.isZero())
 			{
 				auto adelta = actor2->spr.pos - actor->spr.pos;
-				actor2->vel.XY() += adelta.XY() * (1. / SLOPEVAL_FACTOR);
+				actor2->vel += adelta.XY() * (1. / SLOPEVAL_FACTOR);
 
 				if (actor2->spr.statnum == kStatThing)
 				{
@@ -4636,7 +4636,7 @@ static Collision MoveThing(DBloodActor* actor)
 		actor->spr.pos.Z += max(ceilZ - top, 0.);
 		if (actor->vel.Z < 0)
 		{
-			actor->vel.XY() *= 0.75;
+			actor->vel.SetXY(actor->vel.XY() * 0.75);
 			actor->vel.Z *= -0.25;
 
 			switch (actor->spr.type)
@@ -4669,13 +4669,13 @@ static Collision MoveThing(DBloodActor* actor)
 			auto hitActor = coll.actor();
 			if ((hitActor->spr.cstat & CSTAT_SPRITE_ALIGNMENT_MASK) == CSTAT_SPRITE_ALIGNMENT_FACING)
 			{
-				actor->vel.XY() += (actor->spr.pos.XY() - hitActor->spr.pos.XY()) / SLOPEVAL_FACTOR;
+				actor->vel += (actor->spr.pos.XY() - hitActor->spr.pos.XY()) / SLOPEVAL_FACTOR;
 				lhit = actor->hit.hit;
 			}
 		}
 		if (nVel > 0)
 		{
-			actor->vel.XY() -= actor->vel.XY() * nVelClipped / nVel;
+			actor->vel -= actor->vel.XY() * nVelClipped / nVel;
 		}
 	}
 	if (actor->vel.X != 0 || actor->vel.Y != 0)
@@ -5139,7 +5139,7 @@ void MoveDude(DBloodActor* actor)
 			auto hitAct = floorColl.actor();
 			if ((hitAct->spr.cstat & CSTAT_SPRITE_ALIGNMENT_MASK) == CSTAT_SPRITE_ALIGNMENT_FACING)
 			{
-				actor->vel.XY() += (actor->spr.pos - hitAct->spr.pos).XY() * (1. / SLOPEVAL_FACTOR);
+				actor->vel += (actor->spr.pos - hitAct->spr.pos).XY() * (1. / SLOPEVAL_FACTOR);
 				return;
 			}
 		}
@@ -5157,7 +5157,7 @@ void MoveDude(DBloodActor* actor)
 
 		if (actor->vel.XY().Length() < 0.0625)
 		{
-			actor->vel.XY().Zero();
+			actor->vel.SetXY(DVector2(0, 0));
 		}
 	}
 }
@@ -5265,7 +5265,7 @@ int MoveMissile(DBloodActor* actor)
 		if (cliptype >= 0 && cliptype != 3)
 		{
 			double nVel = actor->vel.XY().Length();
-			ppos.XY() -= actor->vel.XY() / nVel;
+			ppos -= actor->vel.XY() / nVel;
 			vel.Z -= actor->vel.Z / nVel;
 			updatesector(ppos, &pSector);
 			pSector2 = pSector;
@@ -5945,7 +5945,7 @@ static void actCheckDudes()
 			// handle incarnations of custom dude
 			if (actor->spr.type == kDudeModernCustom && actor->xspr.txID > 0 && actor->xspr.sysData1 == kGenDudeTransformStatus)
 			{
-				actor->vel.XY().Zero();
+				actor->vel.SetXY(DVector2(0, 0));
 				if (seqGetStatus(actor) < 0) genDudeTransform(actor);
 			}
 #endif
@@ -6088,7 +6088,7 @@ void actCheckFlares()
 		if (target->hasX() && target->xspr.health > 0)
 		{
 			DVector3 pos = target->spr.pos;
-			pos.XY() += (actor->xspr.goalAng + target->spr.Angles.Yaw).ToVector() * target->clipdist * 0.5;
+			pos += (actor->xspr.goalAng + target->spr.Angles.Yaw).ToVector() * target->clipdist * 0.5;
 			pos.Z += actor->xspr.TargetPos.Z;
 			SetActor(actor, pos);
 			actor->vel = target->vel;
@@ -6183,7 +6183,7 @@ DBloodActor* actSpawnDude(DBloodActor* source, int nType, double dist)
 
 	if (dist >= 0)
 	{
-		pos.XY() += angle.ToVector() * dist;
+		pos += angle.ToVector() * dist;
 	}
 	spawned->spr.type = nType;
 	if (!VanillaMode())

--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -2594,7 +2594,7 @@ void actWallBounceVector(DBloodActor* actor, walltype* pWall, double factor)
 	auto vel = actor->vel.XY();
 	double t = vel.X * -delta.Y + vel.Y * delta.X;
 	double t2 = t * (factor+1);
-	actor->vel.XY() = (vel - DVector2(-delta.Y * t2, delta.X * t2));
+	actor->vel.SetXY(vel - DVector2(-delta.Y * t2, delta.X * t2));
 }
 
 //---------------------------------------------------------------------------
@@ -4583,7 +4583,7 @@ static Collision MoveThing(DBloodActor* actor)
 			actor->spr.flags |= 4;
 
 			auto vec4 = actFloorBounceVector(actor, veldiff, actor->sector(), FixedToFloat(pThingInfo->elastic));
-			actor->vel.XY() = vec4.XY();
+			actor->vel.SetXY(vec4.XY());
 			int vax = FloatToFixed(vec4.W);
 
 			int nDamage = MulScale(vax, vax, 30) - pThingInfo->dmgResist;
@@ -5057,7 +5057,7 @@ void MoveDude(DBloodActor* actor)
 		if (veldiff > 0)
 		{
 			auto vec4 = actFloorBounceVector(actor, veldiff, actor->sector(), 0);
-			actor->vel.XY() = vec4.XY();
+			actor->vel.SetXY(vec4.XY());
 			int vax = FloatToFixed(vec4.W);
 
 			int nDamage = MulScale(vax, vax, 30);
@@ -5191,7 +5191,7 @@ int MoveMissile(DBloodActor* actor)
 		if (target->spr.statnum == kStatDude && target->hasX() && target->xspr.health > 0)
 		{
 			double vel = missileInfo[actor->spr.type - kMissileBase].fVelocity();
-			actor->vel.XY() = DVector2(vel, 0).Rotated((target->spr.pos - actor->spr.pos).Angle());
+			actor->vel.SetXY(DVector2(vel, 0).Rotated((target->spr.pos - actor->spr.pos).Angle()));
 
 			double deltaz = (target->spr.pos.Z - actor->spr.pos.Z) / (10 * 256);
 
@@ -6340,7 +6340,7 @@ DBloodActor* actFireThing(DBloodActor* actor, double xyoff, double zoff, double 
 
 	if (HitScan(actor, vect.Z, DVector3(vect.XY() - actor->spr.pos.XY(), 0), CLIPMASK0, actor->clipdist * 0.25) != -1)
 	{
-		vect.XY() = gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * actor->clipdist * 2;
+		vect.SetXY(gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * actor->clipdist * 2);
 	}
 	auto fired = actSpawnThing(actor->sector(), vect, thingType);
 	fired->SetOwner(actor);
@@ -6453,11 +6453,11 @@ DBloodActor* actFireMissile(DBloodActor* actor, double xyoff, double zoff, DVect
 		if (hit == 3 || hit == 0)
 		{
 			impact = true;
-			vect.XY() = gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * 1;
+			vect.SetXY(gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * 1);
 		}
 		else
 		{
-			vect.XY() = gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * pMissileInfo->fClipDist() * 2;
+			vect.SetXY(gHitInfo.hitpos.XY() - actor->spr.Angles.Yaw.ToVector() * pMissileInfo->fClipDist() * 2);
 		}
 	}
 	auto spawned = actSpawnSprite(actor->sector(), vect, 5, 1);

--- a/source/games/blood/src/ai.cpp
+++ b/source/games/blood/src/ai.cpp
@@ -141,7 +141,7 @@ bool CanMove(DBloodActor* actor, DBloodActor* target, DAngle nAngle, double nRan
 			return false;
 		return true;
 	}
-	pos.XY() += nRange / 16 * nAngVect; // see above - same weird mixup.
+	pos += nRange / 16 * nAngVect; // see above - same weird mixup.
 	auto pSector = actor->sector();
 	assert(pSector);
 	auto ps2 = pSector;
@@ -300,7 +300,7 @@ void aiMoveForward(DBloodActor* actor)
 	actor->spr.Angles.Yaw += clamp(nAng, -nTurnRange, nTurnRange);
 	if (abs(nAng) > DAngle60)
 		return;
-	actor->vel.XY() += actor->spr.Angles.Yaw.ToVector() * pDudeInfo->FrontSpeed();
+	actor->vel += actor->spr.Angles.Yaw.ToVector() * pDudeInfo->FrontSpeed();
 }
 
 //---------------------------------------------------------------------------

--- a/source/games/blood/src/aibeast.cpp
+++ b/source/games/blood/src/aibeast.cpp
@@ -66,10 +66,11 @@ void SlashSeqCallback(int, DBloodActor* actor)
 {
 	if (!actor->ValidateTarget(__FUNCTION__)) return;
 	auto target = actor->GetTarget();
-	DVector3 dv;
-	dv.XY() = actor->spr.Angles.Yaw.ToVector();
-	// Correct ?
-	dv.Z = (actor->spr.pos.Z - target->spr.pos.Z) / 64;
+	DVector3 dv(
+		actor->spr.Angles.Yaw.ToVector(),
+		// Correct ?
+		(actor->spr.pos.Z - target->spr.pos.Z) / 64
+	);
 
 	dv.X += Random3(4000 - 700 * gGameOptions.nDifficulty) / 16384.;
 	dv.Y += Random3(4000 - 700 * gGameOptions.nDifficulty) / 16384.;

--- a/source/games/blood/src/aibeast.cpp
+++ b/source/games/blood/src/aibeast.cpp
@@ -401,7 +401,7 @@ static void beastMoveForward(DBloodActor* actor)
 	double nDist = dvec.Length();
 	if (nDist <= 0x40 && Random(64) < 32)
 		return;
-	actor->vel.XY() += actor->spr.Angles.Yaw.ToVector() * pDudeInfo->FrontSpeed();
+	actor->vel += actor->spr.Angles.Yaw.ToVector() * pDudeInfo->FrontSpeed();
 }
 
 static void sub_628A0(DBloodActor* actor)

--- a/source/games/blood/src/aicerber.cpp
+++ b/source/games/blood/src/aicerber.cpp
@@ -100,7 +100,7 @@ void cerberusBurnSeqCallback(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 		
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 		double tsr = nDist * 9.23828125;
 		double top, bottom;
@@ -164,7 +164,7 @@ void cerberusBurnSeqCallback2(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 
 		double tsr = nDist * 9.23828125;

--- a/source/games/blood/src/aicerber.cpp
+++ b/source/games/blood/src/aicerber.cpp
@@ -67,9 +67,10 @@ void cerberusBiteSeqCallback(int, DBloodActor* actor)
 	if (!actor->ValidateTarget(__FUNCTION__)) return;
 	auto target = actor->GetTarget();
 
-	DVector3 vec;
-	vec.XY() = actor->spr.Angles.Yaw.ToVector() * 64;
-	vec.Z = target->spr.pos.Z - actor->spr.pos.Z;
+	DVector3 vec(
+		actor->spr.Angles.Yaw.ToVector() * 64,
+		target->spr.pos.Z - actor->spr.pos.Z
+	);
 	actFireVector(actor, Cerberus_XYOff, -Cerberus_ZOff, vec, kVectorCerberusHack);
 	actFireVector(actor, -Cerberus_XYOff, 0, vec, kVectorCerberusHack);
 	actFireVector(actor, 0, 0, vec, kVectorCerberusHack);
@@ -117,8 +118,7 @@ void cerberusBurnSeqCallback(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), tz1 / nDist);
 				}
 				else
 					Aim.Z = tz1 / 64.;
@@ -187,8 +187,7 @@ void cerberusBurnSeqCallback2(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), tz1 / nDist);
 				}
 				else
 					Aim.Z = tz1 / 64.;

--- a/source/games/blood/src/aigarg.cpp
+++ b/source/games/blood/src/aigarg.cpp
@@ -124,7 +124,7 @@ void BlastSSeqCallback(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 
 		double tsr = nDist * 9.23828125;

--- a/source/games/blood/src/aigarg.cpp
+++ b/source/games/blood/src/aigarg.cpp
@@ -145,8 +145,7 @@ void BlastSSeqCallback(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), tz1 / nDist);
 
 					// This does not make any sense...
 					if (tz1 < -3.2 && tz1 > -48)

--- a/source/games/blood/src/aighost.cpp
+++ b/source/games/blood/src/aighost.cpp
@@ -111,7 +111,7 @@ void ghostBlastSeqCallback(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 
 		double tsr = nDist * 9.23828125;

--- a/source/games/blood/src/aighost.cpp
+++ b/source/games/blood/src/aighost.cpp
@@ -132,8 +132,7 @@ void ghostBlastSeqCallback(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), tz1 / nDist);
 
 					// This does not make any sense...
 					if (tz1 < -3.2 && tz1 > -48)

--- a/source/games/blood/src/aitchern.cpp
+++ b/source/games/blood/src/aitchern.cpp
@@ -103,8 +103,7 @@ void tchernobogBurnSeqCallback(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), tz1 / nDist);
 				}
 				else
 					Aim.Z = tz1 / nDist;
@@ -159,8 +158,7 @@ void tchernobogBurnSeqCallback2(int, DBloodActor* actor)
 				if (cansee(pos, actor->sector(), pos2, actor2->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = nAngle.ToVector();
-					Aim.Z = -tz1 / nDist;
+					Aim = DVector3(nAngle.ToVector(), -tz1 / nDist);
 				}
 				else
 					Aim.Z = -tz1 / nDist;

--- a/source/games/blood/src/aitchern.cpp
+++ b/source/games/blood/src/aitchern.cpp
@@ -82,7 +82,7 @@ void tchernobogBurnSeqCallback(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 
 		double tsr = nDist * 9.23828125;
@@ -137,7 +137,7 @@ void tchernobogBurnSeqCallback2(int, DBloodActor* actor)
 		pos2 += actor->vel * nDist * (65536. / 0x1aaaaa);
 
 		DVector3 tvec = pos;
-		tvec.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		tvec += actor->spr.Angles.Yaw.ToVector() * nDist;
 		tvec.Z += actor->dudeSlope * nDist;
 
 		double tsr = nDist * 9.23828125;

--- a/source/games/blood/src/aiunicult.cpp
+++ b/source/games/blood/src/aiunicult.cpp
@@ -211,7 +211,7 @@ void genDudeAttack1(int, DBloodActor* actor)
 	if (actor->GetTarget() == nullptr) return;
 
 	DVector3 dv;
-	actor->vel.XY().Zero();
+	actor->vel.SetXY(DVector2(0, 0));
 
 	GENDUDEEXTRA* pExtra = &actor->genDudeExtra;
 	int dispersion = pExtra->baseDispersion;
@@ -1772,7 +1772,7 @@ void dudeLeechOperate(DBloodActor* actor, const EVENT& event)
 
 			if (nDist != 0 && cansee(DVector3(actor->spr.pos.XY(), top), actor->sector(), atpos, actTarget->sector()))
 			{
-				atpos.XY() += actTarget->vel.XY() * nDist * 0.0375;
+				atpos += actTarget->vel.XY() * nDist * 0.0375;
 
 				auto angBak = actor->spr.Angles.Yaw;
 				actor->spr.Angles.Yaw = (atpos - actor->spr.pos.XY()).Angle();
@@ -1855,7 +1855,7 @@ DBloodActor* genDudeSpawn(DBloodActor* source, DBloodActor* actor, double nDist)
 	auto pos = actor->spr.pos;
 	if (nDist > 0)
 	{
-		pos.XY() += actor->spr.Angles.Yaw.ToVector() * nDist;
+		pos += actor->spr.Angles.Yaw.ToVector() * nDist;
 	}
 
 	spawned->spr.type = nType; 

--- a/source/games/blood/src/aiunicult.cpp
+++ b/source/games/blood/src/aiunicult.cpp
@@ -1776,10 +1776,11 @@ void dudeLeechOperate(DBloodActor* actor, const EVENT& event)
 
 				auto angBak = actor->spr.Angles.Yaw;
 				actor->spr.Angles.Yaw = (atpos - actor->spr.pos.XY()).Angle();
-				DVector3 dv;
-				dv.XY() = actor->spr.Angles.Yaw.ToVector() * 64;
 				double tz = actTarget->spr.pos.Z - (actTarget->spr.scale.Y * pDudeInfo->aimHeight);
-				double dz = (tz - top - 1) / nDist * 4;
+				DVector3 dv(
+					actor->spr.Angles.Yaw.ToVector() * 64,
+					(tz - top - 1) / nDist * 4
+				);
 				int nMissileType = kMissileLifeLeechAltNormal + (actor->xspr.data3 ? 1 : 0);
 				int t2;
 

--- a/source/games/blood/src/aizomba.cpp
+++ b/source/games/blood/src/aizomba.cpp
@@ -64,12 +64,13 @@ void HackSeqCallback(int, DBloodActor* actor)
 	if (!target) return;
 	DUDEINFO* pDudeInfo = getDudeInfo(actor->spr.type);
 	DUDEINFO* pDudeInfoT = getDudeInfo(target->spr.type);
-	DVector3 dv;
-	dv.XY() = (actor->xspr.TargetPos.XY() - actor->spr.pos.XY()).Resized(64);
 
 	double height = (pDudeInfo->eyeHeight * actor->spr.scale.Y);
 	double height2 = (pDudeInfoT->eyeHeight * target->spr.scale.Y);
-	dv.Z = height - height2;
+	DVector3 dv(
+		(actor->xspr.TargetPos.XY() - actor->spr.pos.XY()).Resized(64),
+		height - height2
+	);
 
 	sfxPlay3DSound(actor, 1101, 1, 0);
 	actFireVector(actor, 0, 0, dv, kVectorAxe);

--- a/source/games/blood/src/animatesprite.cpp
+++ b/source/games/blood/src/animatesprite.cpp
@@ -98,7 +98,7 @@ tspritetype* viewInsertTSprite(tspriteArray& tsprites, sectortype* pSector, int 
 		pTSprite->ownerActor = parentTSprite->ownerActor;
 		pTSprite->Angles.Yaw = parentTSprite->Angles.Yaw;
 	}
-	pos.XY() += gCameraAng.ToVector() * 2;
+	pos += gCameraAng.ToVector() * 2;
 	pTSprite->pos = pos;
 	return pTSprite;
 }
@@ -510,7 +510,7 @@ static tspritetype* viewAddEffect(tspriteArray& tsprites, int nTSprite, VIEW_EFF
 			pNSprite->cstat &= ~CSTAT_SPRITE_YFLIP;
 			if (pPlayer->curWeapon == kWeapLifeLeech) // position lifeleech behind player
 			{
-				pNSprite->pos.XY() += gView->GetActor()->spr.Angles.Yaw.ToVector() * 8;
+				pNSprite->pos += gView->GetActor()->spr.Angles.Yaw.ToVector() * 8;
 			}
 			if ((pPlayer->curWeapon == kWeapLifeLeech) || (pPlayer->curWeapon == kWeapVoodooDoll))  // make lifeleech/voodoo doll always face viewer like sprite
 				pNSprite->Angles.Yaw += DAngle90;
@@ -867,7 +867,7 @@ void viewProcessSprites(tspriteArray& tsprites, const DVector3& cPos, DAngle cA,
 					auto pNTSprite = viewAddEffect(tsprites, nTSprite, kViewEffectShoot);
 					if (pNTSprite) {
 						POSTURE* pPosture = &thisPlayer->pPosture[thisPlayer->lifeMode][thisPlayer->posture];
-						pNTSprite->pos.XY() += pTSprite->Angles.Yaw.ToVector() * pPosture->xOffset;
+						pNTSprite->pos += pTSprite->Angles.Yaw.ToVector() * pPosture->xOffset;
 						pNTSprite->pos.Z = thisPlayer->GetActor()->spr.pos.Z - pPosture->zOffset;
 					}
 				}

--- a/source/games/blood/src/fx.cpp
+++ b/source/games/blood/src/fx.cpp
@@ -333,8 +333,7 @@ void fxSpawnEjectingBrass(DBloodActor* actor, double z, double dist, int rdist)
 		int iDist = (rdist << 18) / 120 + Random2(((rdist / 4) << 18) / 120);
 		double nDist = iDist / 65536.;
 		DAngle nAngle = actor->spr.Angles.Yaw + Random2A(56) + DAngle90;
-		pBrass->vel.XY() = nAngle.ToVector() * nDist;
-		pBrass->vel.Z = actor->vel.Z - 2 - Random2(40) / 30.;
+		pBrass->vel = DVector3(nAngle.ToVector() * nDist, actor->vel.Z - 2 - Random2(40) / 30.);
 	}
 }
 
@@ -356,8 +355,7 @@ void fxSpawnEjectingShell(DBloodActor* actor, double z, double dist, int rdist)
 		int iDist = (rdist << 18) / 120 + Random2(((rdist / 4) << 18) / 120);
 		double nDist = iDist / 65536.;
 		DAngle nAngle = actor->spr.Angles.Yaw + Random2A(56) + DAngle90;
-		pShell->vel.XY() = nAngle.ToVector() * nDist;
-		pShell->vel.Z = actor->vel.Z - 2 - Random2(28) / 30.;
+		pShell->vel = DVector3(nAngle.ToVector() * nDist, actor->vel.Z - 2 - Random2(28) / 30.);
 	}
 }
 

--- a/source/games/blood/src/gib.cpp
+++ b/source/games/blood/src/gib.cpp
@@ -481,8 +481,7 @@ void GibWall(walltype* pWall, GIBTYPE nGibType, DVector3* pVel)
 	assert(pWall);
 	assert(nGibType >= 0 && nGibType < kGibMax);
 
-	DVector3 center;
-	center.XY() = pWall->center();
+	DVector3 center(pWall->center(), 0);
 
 	auto pSector = pWall->sectorp();
 	double ceilZ, floorZ;
@@ -492,9 +491,7 @@ void GibWall(walltype* pWall, GIBTYPE nGibType, DVector3* pVel)
 
 	ceilZ = max(ceilZ, ceilZ2);
 	floorZ = min(floorZ, floorZ2);
-	DVector3 w;
-	w.Z = floorZ - ceilZ;
-	w.XY() = pWall->delta();
+	DVector3 w(pWall->delta(), floorZ - ceilZ);
 	center.Z = (ceilZ + floorZ) * 0.5;
 
 	GIBLIST* pGib = &gibList[nGibType];

--- a/source/games/blood/src/nnexts.cpp
+++ b/source/games/blood/src/nnexts.cpp
@@ -1594,9 +1594,10 @@ void debrisBubble(DBloodActor* actor)
 	for (unsigned int i = 0; i < 1 + Random(5); i++)
 	{
 		DAngle nAngle = RandomAngle();
-		DVector3 pos;
-		pos.XY() = actor->spr.pos.XY() + nAngle.ToVector() * nDist;
-		pos.Z = bottom - RandomD(bottom - top, 8);
+		DVector3 pos(
+			actor->spr.pos.XY() + nAngle.ToVector() * nDist,
+			bottom - RandomD(bottom - top, 8)
+		);
 		auto pFX = gFX.fxSpawnActor((FX_ID)(FX_23 + Random(3)), actor->sector(), pos, nullAngle);
 		if (pFX) {
 			pFX->vel.X = actor->vel.X + Random2F(0x1aaaa);
@@ -3099,7 +3100,7 @@ void useVelocityChanger(DBloodActor* actor, sectortype* sect, DBloodActor* initi
 			
 			auto velv = pSprite->vel.XY();
 			auto pt = rotatepoint(pSprite->spr.pos.XY(), velv, angl);
-			pSprite->vel.XY() = pt;
+			pSprite->vel.SetXY(pt);
 
 
 			vAng = pSprite->vel.Angle();
@@ -3145,7 +3146,7 @@ void useTeleportTarget(DBloodActor* sourceactor, DBloodActor* actor)
 	if (actor->sector() != sourceactor->sector())
 		ChangeActorSect(actor, sourceactor->sector());
 
-	actor->spr.pos.XY() =sourceactor->spr.pos.XY();
+	actor->spr.pos.SetXY(sourceactor->spr.pos.XY());
 	double zTop, zBot;
 	GetActorExtents(sourceactor, &zTop, &zBot);
 	actor->spr.pos.Z = zBot;
@@ -3251,8 +3252,7 @@ void useTeleportTarget(DBloodActor* sourceactor, DBloodActor* actor)
 		{
 			auto velv = actor->vel.XY();
 			auto pt = rotatepoint(actor->spr.pos.XY(), velv, sourceactor->spr.Angles.Yaw - velv.Angle());
-			actor->vel.XY() = pt;
-
+			actor->vel.SetXY(pt);
 		}
 
 		if (sourceactor->xspr.data3 & kModernTypeFlag4)
@@ -3719,7 +3719,7 @@ void useSeqSpawnerGen(DBloodActor* sourceactor, int objType, sectortype* pSector
 			{
 				DVector3 cpos;
 				
-				cpos.XY() = pWall->center();
+				cpos.SetXY(pWall->center());
 				auto pMySector = pWall->sectorp();
 				double ceilZ, floorZ;
 				calcSlope(pSector, cpos, &ceilZ, &floorZ);
@@ -6498,8 +6498,10 @@ void useUniMissileGen(DBloodActor* sourceactor, DBloodActor* actor)
 	}
 	else
 	{
-		dv.XY() = actor->spr.Angles.Yaw.ToVector();
-		dv.Z = clamp(sourceactor->xspr.data3 / 256., -4., 4.); // add slope controlling
+		dv = DVector3(
+			actor->spr.Angles.Yaw.ToVector(),
+			clamp(sourceactor->xspr.data3 / 256., -4., 4.) // add slope controlling
+		);
 	}
 
 	auto missileactor = actFireMissile(actor, 0, 0, dv, actor->xspr.data1);

--- a/source/games/blood/src/nnexts.cpp
+++ b/source/games/blood/src/nnexts.cpp
@@ -1834,7 +1834,7 @@ void debrisMove(int listIndex)
 
 		if ((floorColl.actor()->spr.cstat & CSTAT_SPRITE_ALIGNMENT_MASK) == 0)
 		{
-			actor->vel.XY() += (actor->spr.pos.XY() - floorColl.actor()->spr.pos.XY()) / 4096.;
+			actor->vel += (actor->spr.pos.XY() - floorColl.actor()->spr.pos.XY()) / 4096.;
 			return;
 		}
 	}
@@ -1847,9 +1847,9 @@ void debrisMove(int listIndex)
 	if (actor->xspr.height > 0)
 		nDrag *= 1 - actor->xspr.height / 256.;
 
-	actor->vel.XY() *= 1 - nDrag;
+	actor->vel.SetXY(actor->vel.XY() * (1 - nDrag));
 	if (actor->vel.XY().LengthSquared() < 1 / 256.)
-		actor->vel.XY().Zero();
+		actor->vel.SetXY(DVector2(0, 0));
 }
 
 //---------------------------------------------------------------------------
@@ -3042,7 +3042,7 @@ void useVelocityChanger(DBloodActor* actor, sectortype* sect, DBloodActor* initi
 			double v = actor->xspr.data1 * kVelScale;
 			if (v != 0) v += rr;
 
-			vv.XY() += nAng.ToVector() * v;
+			vv += nAng.ToVector() * v;
 		}
 
 		if (actor->xspr.physAttr)
@@ -8166,7 +8166,7 @@ void aiPatrolMove(DBloodActor* actor)
 
 	if (abs(nAng) > goalAng || ((targetactor->xspr.waitTime > 0 || targetactor->xspr.data1 == targetactor->xspr.data2) && aiPatrolMarkerReached(actor)))
 	{
-		actor->vel.XY().Zero();
+		actor->vel.SetXY(DVector2(0, 0));
 		return;
 	}
 

--- a/source/games/blood/src/player.cpp
+++ b/source/games/blood/src/player.cpp
@@ -1686,8 +1686,10 @@ void ProcessInput(DBloodPlayer* pPlayer)
 			if (spawned)
 			{
 				spawned->spr.Angles.Yaw += DAngle180;
-				spawned->vel.XY() = pPlayer->GetActor()->vel.XY() + (64. / 3.) * pPlayer->GetActor()->spr.Angles.Yaw.ToVector();
-				spawned->vel.Z = pPlayer->GetActor()->vel.Z;
+				spawned->vel = DVector3(
+					pPlayer->GetActor()->vel.XY() + (64. / 3.) * pPlayer->GetActor()->spr.Angles.Yaw.ToVector(),
+					pPlayer->GetActor()->vel.Z
+				);
 			}
 			pPlayer->hand = 0;
 		}

--- a/source/games/blood/src/player.cpp
+++ b/source/games/blood/src/player.cpp
@@ -724,7 +724,7 @@ void playerCorrectInertia(DBloodPlayer* pPlayer, const DVector3& oldpos)
 	auto zAdj = pPlayer->GetActor()->spr.pos.Z - oldpos.Z;
 	pPlayer->zView += zAdj;
 	pPlayer->zWeapon += zAdj;
-	pPlayer->GetActor()->opos.XY() += pPlayer->GetActor()->spr.pos.XY() - oldpos.XY();
+	pPlayer->GetActor()->opos += pPlayer->GetActor()->spr.pos.XY() - oldpos.XY();
 	pPlayer->ozView += zAdj;
 	pPlayer->GetActor()->opos.Z += zAdj;
 }
@@ -1566,7 +1566,7 @@ void ProcessInput(DBloodPlayer* pPlayer)
 		const double speed = pPlayer->posture == 1? 1. : 1. - (actor->xspr.height * (1. / 256.) * (actor->xspr.height < 256));
 		pInput->vel.X *= pInput->vel.X > 0 ? pPosture->frontAccel : pPosture->backAccel;
 		pInput->vel.Y *= pPosture->sideAccel;
-		actor->vel.XY() += pInput->vel.XY().Rotated(actor->spr.Angles.Yaw) * speed;
+		actor->vel += pInput->vel.XY().Rotated(actor->spr.Angles.Yaw) * speed;
 		pPlayer->RollVel += pInput->vel.Y * speed;
 	}
 

--- a/source/games/blood/src/triggers.cpp
+++ b/source/games/blood/src/triggers.cpp
@@ -270,7 +270,7 @@ void LifeLeechOperate(DBloodActor* actor, EVENT event)
 					auto nDist = (pos.XY() - actor->spr.pos.XY()).Length();
 					if (nDist != 0 && cansee(DVector3(actor->spr.pos.XY(), top), actor->sector(), pos, target->sector()))
 					{
-						pos.XY() += target->vel.XY() * nDist * (65536. / 0x1aaaaa);
+						pos += target->vel.XY() * nDist * (65536. / 0x1aaaaa);
 						auto angBak = actor->spr.Angles.Yaw;
 						actor->spr.Angles.Yaw = (pos.XY() - actor->spr.pos.XY()).Angle();
 						double tz = target->spr.pos.Z - (target->spr.scale.Y * pDudeInfo->aimHeight);

--- a/source/games/blood/src/triggers.cpp
+++ b/source/games/blood/src/triggers.cpp
@@ -908,7 +908,7 @@ void TranslateSector(sectortype* pSector, double wave1, double wave2, const DVec
 		{
 			auto spot = rotatepoint(pivot, actor->basePoint.XY(), ptang_w2);
 			viewBackupSpriteLoc(actor);
-			actor->spr.pos.XY() = spot + pt_w2 - pivot;
+			actor->spr.pos.SetXY(spot + pt_w2 - pivot);
 			actor->spr.Angles.Yaw += angleofs;
 
 		}
@@ -919,7 +919,7 @@ void TranslateSector(sectortype* pSector, double wave1, double wave2, const DVec
 
 			auto spot = rotatepoint(pivotDy, actor->basePoint.XY(), ptang_w2);
 			viewBackupSpriteLoc(actor);
-			actor->spr.pos.XY() = spot - pt_w2 + pivot;
+			actor->spr.pos.SetXY(spot - pt_w2 + pivot);
 			actor->spr.Angles.Yaw += angleofs;
 		}
 		else if (pXSector->Drag)
@@ -932,7 +932,7 @@ void TranslateSector(sectortype* pSector, double wave1, double wave2, const DVec
 				viewBackupSpriteLoc(actor);
 				if (angleofs != nullAngle)
 				{
-					actor->spr.pos.XY() = rotatepoint(pt_w1, actor->spr.pos.XY(), angleofs);
+					actor->spr.pos.SetXY(rotatepoint(pt_w1, actor->spr.pos.XY(), angleofs));
 				}
 				actor->spr.Angles.Yaw += angleofs;
 				actor->spr.pos += position;
@@ -958,7 +958,7 @@ void TranslateSector(sectortype* pSector, double wave1, double wave2, const DVec
 				{
 					auto spot = rotatepoint(pivot, ac->basePoint.XY(), ptang_w2);
 					viewBackupSpriteLoc(ac);
-					ac->spr.pos.XY() = spot + pt_w2 - pivot;
+					ac->spr.pos.SetXY(spot + pt_w2 - pivot);
 					ac->spr.Angles.Yaw += angleofs;
 					if (!VanillaMode() && ac->IsPlayerActor()) getPlayer(ac->spr.type - kDudePlayer1)->GetActor()->spr.Angles.Yaw += angleofs;
 				}
@@ -966,7 +966,7 @@ void TranslateSector(sectortype* pSector, double wave1, double wave2, const DVec
 				{
 					auto spot = rotatepoint(pivot, ac->basePoint.XY(), ptang_w2);
 					viewBackupSpriteLoc(ac);
-					ac->spr.pos.XY() = spot - pt_w2 + pivot;
+					ac->spr.pos.SetXY(spot - pt_w2 + pivot);
 					ac->spr.Angles.Yaw += angleofs;
 					if (!VanillaMode() && ac->IsPlayerActor()) getPlayer(ac->spr.type - kDudePlayer1)->GetActor()->spr.Angles.Yaw += angleofs;
 				}
@@ -1608,7 +1608,7 @@ void OperateTeleport(sectortype* pSector)
 				{
 					TeleFrag(pXSector->actordata, destactor->sector());
 				}
-				actor->spr.pos.XY() = destactor->spr.pos.XY();
+				actor->spr.pos.SetXY(destactor->spr.pos.XY());
 				actor->spr.pos.Z += destactor->sector()->floorz - pSector->floorz;
 				actor->spr.Angles.Yaw = destactor->spr.Angles.Yaw;
 				ChangeActorSect(actor, destactor->sector());
@@ -2536,7 +2536,7 @@ void MGunFireSeqCallback(int, DBloodActor* actor)
 				evPostActor(actor, 1, kCmdOff, actor);
 		}
 		DVector3 dv;
-		dv.XY() = actor->spr.Angles.Yaw.ToVector();
+		dv.SetXY(actor->spr.Angles.Yaw.ToVector());
 		dv.X += Random2F(1000, 14);
 		dv.Y += Random2F(1000, 14);
 		dv.Z = Random2F(1000, 14);

--- a/source/games/blood/src/view.cpp
+++ b/source/games/blood/src/view.cpp
@@ -472,7 +472,7 @@ static void SetupView(DBloodPlayer* pPlayer, DVector3& cPos, DRotator& cAngles, 
 	{
 		if (cl_viewhbob)
 		{
-			cPos.XY() -= cAngles.Yaw.ToVector().Rotated90CW() * bobWidth;
+			cPos -= cAngles.Yaw.ToVector().Rotated90CW() * bobWidth;
 		}
 		if (cl_viewvbob)
 		{

--- a/source/games/blood/src/warp.cpp
+++ b/source/games/blood/src/warp.cpp
@@ -211,7 +211,7 @@ int CheckLink(DBloodActor* actor)
 			assert(aLower);
 			assert(aLower->insector());
 			ChangeActorSect(actor, aLower->sector());
-			actor->spr.pos.XY() += aLower->spr.pos.XY() - aUpper->spr.pos.XY();
+			actor->spr.pos += aLower->spr.pos.XY() - aUpper->spr.pos.XY();
 			double z2;
 			if (aLower->spr.type == kMarkerLowLink)
 				z2 = aLower->spr.pos.Z;
@@ -235,7 +235,7 @@ int CheckLink(DBloodActor* actor)
 			assert(aUpper);
 			assert(aUpper->insector());
 			ChangeActorSect(actor, aUpper->sector());
-			actor->spr.pos.XY() += aUpper->spr.pos.XY() - aLower->spr.pos.XY();
+			actor->spr.pos += aUpper->spr.pos.XY() - aLower->spr.pos.XY();
 			double z2;
 			if (aUpper->spr.type == kMarkerUpLink)
 				z2 = aUpper->spr.pos.Z;
@@ -272,7 +272,7 @@ int CheckLink(DVector3& cPos, sectortype** pSector)
 			assert(aLower);
 			assert(aLower->insector());
 			*pSector = aLower->sector();
-			cPos.XY() += aLower->spr.pos.XY() - aUpper->spr.pos.XY();
+			cPos += aLower->spr.pos.XY() - aUpper->spr.pos.XY();
 			double z2;
 			if (aUpper->spr.type == kMarkerLowLink)
 				z2 = aLower->spr.pos.Z;
@@ -294,7 +294,7 @@ int CheckLink(DVector3& cPos, sectortype** pSector)
 			aUpper = aLower->GetOwner();
 			assert(aUpper);
 			*pSector = aUpper->sector();
-			cPos.XY() += aUpper->spr.pos.XY() - aLower->spr.pos.XY();
+			cPos += aUpper->spr.pos.XY() - aLower->spr.pos.XY();
 			double z2;
 			if (aLower->spr.type == kMarkerUpLink)
 				z2 = aUpper->spr.pos.Z;

--- a/source/games/blood/src/weapon.cpp
+++ b/source/games/blood/src/weapon.cpp
@@ -498,7 +498,7 @@ void UpdateAimVector(DBloodPlayer* pPlayer)
 				double dzCenter = (pos2.Z - center) - pos.Z;
 
 				nClosest = nDist2;
-				Aim.XY() = angle.ToVector();
+				Aim.SetXY(angle.ToVector());
 				Aim.Z = dzCenter / nDist;
 				targetactor = actor;
 			}
@@ -541,7 +541,7 @@ void UpdateAimVector(DBloodPlayer* pPlayer)
 				if (cansee(pos, plActor->sector(), pos2, actor->sector()))
 				{
 					nClosest = nDist2;
-					Aim.XY() = angle.ToVector();
+					Aim.SetXY(angle.ToVector());
 					Aim.Z = dv.Z / nDist;
 					targetactor = actor;
 				}
@@ -549,14 +549,14 @@ void UpdateAimVector(DBloodPlayer* pPlayer)
 		}
 	}
 	DVector3 Aim2(Aim);
-	Aim2.XY() = Aim2.XY().Rotated(-plActor->spr.Angles.Yaw);
+	Aim2.SetXY(Aim2.XY().Rotated(-plActor->spr.Angles.Yaw));
 	Aim2.Z -= pPlayer->slope;
 
 	pPlayer->relAim.X = interpolatedvalue(pPlayer->relAim.X, Aim2.X, FixedToFloat(pWeaponTrack->aimSpeedHorz));
 	pPlayer->relAim.Y = interpolatedvalue(pPlayer->relAim.Y, Aim2.Y, FixedToFloat(pWeaponTrack->aimSpeedHorz));
 	pPlayer->relAim.Z = interpolatedvalue(pPlayer->relAim.Z, Aim2.Z, FixedToFloat(pWeaponTrack->aimSpeedVert));
 	pPlayer->aim = pPlayer->relAim;
-	pPlayer->aim.XY() = pPlayer->aim.XY().Rotated(plActor->spr.Angles.Yaw);
+	pPlayer->aim.SetXY(pPlayer->aim.XY().Rotated(plActor->spr.Angles.Yaw));
 	pPlayer->aim.Z += pPlayer->slope;
 	pPlayer->aimTarget = targetactor;
 }

--- a/source/games/duke/src/actors.cpp
+++ b/source/games/duke/src/actors.cpp
@@ -1264,7 +1264,7 @@ int movesprite_ex(DDukeActor* actor, const DVector3& change, unsigned int clipty
 		else
 			clipmove(ppos, &dasectp, change.XY() * 0.5, actor->clipdist, 4., 4., cliptype, result);
 	}
-	actor->spr.pos.XY() = ppos.XY();
+	actor->spr.pos.SetXY(ppos.XY());
 
 	if (dasectp != nullptr && dasectp != actor->sector())
 		ChangeActorSect(actor, dasectp);
@@ -1619,7 +1619,7 @@ void handle_se00(DDukeActor* actor)
 		if (actor->temp_pos.Y == 0)
 			actor->temp_pos.Y = (actor->spr.pos.XY() - Owner->spr.pos.XY()).Length();
 		actor->vel.X = actor->temp_pos.Y;
-		actor->spr.pos.XY() = Owner->spr.pos.XY();
+		actor->spr.pos.SetXY(Owner->spr.pos.XY());
 		actor->spr.Angles.Yaw += ang_amount * direction;
 		actor->temp_angle += ang_amount * direction;
 	}
@@ -1639,7 +1639,7 @@ void handle_se00(DDukeActor* actor)
 
 				auto result = rotatepoint(Owner->spr.pos.XY(), pact->spr.pos.XY(), ang_amount * direction);
 				p->bobpos += (result - pact->spr.pos.XY());
-				pact->spr.pos.XY() = result;
+				pact->spr.pos.SetXY(result);
 			}
 		}
 		DukeSectIterator itp(actor->sector());
@@ -1783,7 +1783,7 @@ void handle_se14(DDukeActor* actor, bool checkstat, PClassActor* RPG)
 					updatesector(pact->getPosWithOffsetZ(), &sect);
 					if ((sect == nullptr && ud.clipping == 0) || (sect == actor->sector() && p->cursector != actor->sector()))
 					{
-						pact->spr.pos.XY() = actor->spr.pos.XY();
+						pact->spr.pos.SetXY(actor->spr.pos.XY());
 						p->setCursector(actor->sector());
 
 						SetActor(pact, actor->spr.pos);
@@ -1810,7 +1810,7 @@ void handle_se14(DDukeActor* actor, bool checkstat, PClassActor* RPG)
 				if (actor->sector() == pact->sector())
 				{
 					auto result = rotatepoint(actor->spr.pos.XY(), pact->spr.pos.XY(), diffangle);
-					pact->spr.pos.XY() = result + vec;
+					pact->spr.pos.SetXY(result + vec);
 
 					p->bobpos += vec;
 					pact->spr.Angles.Yaw += diffangle;
@@ -1821,7 +1821,7 @@ void handle_se14(DDukeActor* actor, bool checkstat, PClassActor* RPG)
 					}
 					if (pact->spr.extra <= 0)
 					{
-						pact->spr.pos.XY() = pact->spr.pos.XY();
+						pact->spr.pos.SetXY(pact->spr.pos.XY());
 					}
 				}
 			}
@@ -1833,7 +1833,7 @@ void handle_se14(DDukeActor* actor, bool checkstat, PClassActor* RPG)
 				(!iseffector(a2) || a2->spr.lotag == SE_49_POINT_LIGHT || a2->spr.lotag == SE_50_SPOT_LIGHT) &&
 				!islocator(a2))
 			{
-				a2->spr.pos.XY() = rotatepoint(actor->spr.pos.XY(), a2->spr.pos.XY(), diffangle) + vec;
+				a2->spr.pos.SetXY(rotatepoint(actor->spr.pos.XY(), a2->spr.pos.XY(), diffangle) + vec);
 				a2->spr.Angles.Yaw += diffangle;
 
 				if (numplayers > 1)
@@ -1860,7 +1860,7 @@ void handle_se14(DDukeActor* actor, bool checkstat, PClassActor* RPG)
 					updatesector(pact->getPosWithOffsetZ(), &k);
 					if ((k == nullptr && ud.clipping == 0) || (k == actor->sector() && p->cursector != actor->sector()))
 					{
-						pact->spr.pos.XY() = actor->spr.pos.XY();
+						pact->spr.pos.SetXY(actor->spr.pos.XY());
 						pact->backupvec2();
 						p->setCursector(actor->sector());
 
@@ -1965,7 +1965,7 @@ void handle_se30(DDukeActor *actor)
 					updatesector(pact->getPosWithOffsetZ(), &k);
 					if ((k == nullptr && ud.clipping == 0) || (k == actor->sector() && p->cursector != actor->sector()))
 					{
-						pact->spr.pos.XY() = actor->spr.pos.XY();
+						pact->spr.pos.SetXY(actor->spr.pos.XY());
 						p->setCursector(actor->sector());
 
 						SetActor(pact, actor->spr.pos);
@@ -2030,7 +2030,7 @@ void handle_se30(DDukeActor *actor)
 						updatesector(pact->getPosWithOffsetZ(), &k);
 						if ((k == nullptr && ud.clipping == 0) || (k == actor->sector() && p->cursector != actor->sector()))
 						{
-							pact->spr.pos.XY() = actor->spr.pos.XY();
+							pact->spr.pos.SetXY(actor->spr.pos.XY());
 							pact->backupvec2();
 
 							p->setCursector(actor->sector());
@@ -3229,7 +3229,7 @@ void handle_se26(DDukeActor* actor)
 	actor->spr.shade++;
 	if (actor->spr.shade > 7)
 	{
-		actor->spr.pos.XY() = actor->temp_pos.XY();
+		actor->spr.pos.SetXY(actor->temp_pos.XY());
 		sc->addfloorz(-((zvel * actor->spr.shade) - zvel));
 		actor->spr.shade = 0;
 	}

--- a/source/games/duke/src/actors.cpp
+++ b/source/games/duke/src/actors.cpp
@@ -404,7 +404,7 @@ void lotsofstuff(DDukeActor* actor, int n, PClassActor* spawntype)
 void movesector(DDukeActor* const actor, int msindex, DAngle rotation)
 {
 	//T1,T2 and T3 are used for all the sector moving stuff!!!
-	actor->spr.pos.XY() += actor->spr.Angles.Yaw.ToVector() * actor->vel.X;
+	actor->spr.pos += actor->spr.Angles.Yaw.ToVector() * actor->vel.X;
 
 	for(auto& wal : actor->sector()->walls)
 	{
@@ -502,7 +502,7 @@ void movedummyplayers(void)
 			}
 		}
 
-		act->spr.pos.XY() += pact->spr.pos.XY() - pact->opos.XY();
+		act->spr.pos += pact->spr.pos.XY() - pact->opos.XY();
 		SetActor(act, act->spr.pos);
 	}
 }
@@ -852,20 +852,20 @@ void checkdive(DDukeActor* transporter, DDukeActor* transported)
 			}
 			else
 			{
-				transported->spr.pos.XY() += Owner->spr.pos.XY() - transporter->spr.pos.XY();
+				transported->spr.pos += Owner->spr.pos.XY() - transporter->spr.pos.XY();
 				transported->spr.pos.Z = Owner->spr.pos.Z + 16;
 				transported->backupz();
 				ChangeActorSect(transported, Owner->sector());
 			}
 			break;
 		case ST_1_ABOVE_WATER:
-			transported->spr.pos.XY() += Owner->spr.pos.XY() - transporter->spr.pos.XY();
+			transported->spr.pos += Owner->spr.pos.XY() - transporter->spr.pos.XY();
 			transported->spr.pos.Z = Owner->sector()->ceilingz + ll;
 			transported->backupz();
 			ChangeActorSect(transported, Owner->sector());
 			break;
 		case ST_2_UNDERWATER:
-			transported->spr.pos.XY() += Owner->spr.pos.XY() - transporter->spr.pos.XY();
+			transported->spr.pos += Owner->spr.pos.XY() - transporter->spr.pos.XY();
 			transported->spr.pos.Z = Owner->sector()->ceilingz - ll;
 			transported->backupz();
 			ChangeActorSect(transported, Owner->sector());
@@ -873,7 +873,7 @@ void checkdive(DDukeActor* transporter, DDukeActor* transported)
 
 		case ST_160_FLOOR_TELEPORT:
 			if (!(ud.mapflags & MFLAG_ALLSECTORTYPES)) break;
-			transported->spr.pos.XY() += Owner->spr.pos.XY() - transporter->spr.pos.XY();
+			transported->spr.pos += Owner->spr.pos.XY() - transporter->spr.pos.XY();
 			transported->spr.pos.Z = Owner->sector()->ceilingz + ll2;
 			transported->backupz();
 
@@ -1459,7 +1459,7 @@ void move(DDukeActor* actor, DDukePlayer* const p, double pdist)
 				}
 				else
 				{
-					p->vel.XY() *= gs.playerfriction - 0.125;
+					p->vel.SetXY(p->vel.XY() * (gs.playerfriction - 0.125));
 				}
 			}
 			else if (!(actor->flags2 & SFLAG2_FLOATING))
@@ -1982,7 +1982,7 @@ void handle_se30(DDukeActor *actor)
 
 			if (pact->sector() == actor->sector())
 			{
-				pact->spr.pos.XY() += vect;
+				pact->spr.pos += vect;
 
 				if (numplayers > 1)
 				{
@@ -2119,7 +2119,7 @@ void handle_se02(DDukeActor* actor)
 
 			if (p->cursector == actor->sector() && p->on_ground)
 			{
-				p->GetActor()->spr.pos.XY() += vect;
+				p->GetActor()->spr.pos += vect;
 				p->bobpos += vect;
 			}
 		}
@@ -2833,7 +2833,7 @@ void handle_se17(DDukeActor* actor)
 				const auto p = getPlayer(act3->PlayerIndex());
 
 				act3->opos -= act3->spr.pos;
-				act3->spr.pos.XY() += act2->spr.pos.XY() - actor->spr.pos.XY();
+				act3->spr.pos += act2->spr.pos.XY() - actor->spr.pos.XY();
 				act3->spr.pos.Z += act2->sector()->floorz - sc->floorz;
 				act3->opos += act3->spr.pos;
 
@@ -2854,7 +2854,7 @@ void handle_se17(DDukeActor* actor)
 			else if (act3->spr.statnum != STAT_EFFECTOR)
 			{
 				act3->opos -= act3->spr.pos;
-				act3->spr.pos.XY() += act2->spr.pos.XY() - actor->spr.pos.XY();
+				act3->spr.pos += act2->spr.pos.XY() - actor->spr.pos.XY();
 				act3->spr.pos.Z += act2->sector()->floorz - sc->floorz;
 				act3->opos += act3->spr.pos;
 
@@ -3138,7 +3138,7 @@ void handle_se20(DDukeActor* actor)
 
 			if (p->cursector == actor->sector() && p->on_ground)
 			{
-				pact->spr.pos.XY() += vec;
+				pact->spr.pos += vec;
 				pact->backupvec2();
 				SetActor(pact, pact->spr.pos);
 			}

--- a/source/games/duke/src/actors_d.cpp
+++ b/source/games/duke/src/actors_d.cpp
@@ -188,11 +188,11 @@ int ifhitbyweapon_d(DDukeActor *actor)
 
 				if (adef->flags2 & SFLAG2_DOUBLEDMGTHRUST)
 				{
-					p->vel.XY() += actor->hitang.ToVector() * actor->hitextra * 0.25;
+					p->vel += actor->hitang.ToVector() * actor->hitextra * 0.25;
 				}
 				else
 				{
-					p->vel.XY() += actor->hitang.ToVector() * actor->hitextra * 0.125;
+					p->vel += actor->hitang.ToVector() * actor->hitextra * 0.125;
 				}
 			}
 			else
@@ -342,7 +342,7 @@ void movetransports_d(void)
 						if ((p->jetpack_on == 0) || (p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_JUMP) || p->cmd.ucmd.vel.Z > 0)) ||
 							(p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_CROUCH) || p->cmd.ucmd.vel.Z < 0)))
 						{
-							act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+							act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 							act2->backupvec2();
 
 							if (p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_JUMP) || p->jetpack_on < 11))
@@ -416,7 +416,7 @@ void movetransports_d(void)
 
 					if (k == 1)
 					{
-						act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+						act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 						act2->backupvec2();
 
 						if (!Owner || Owner->GetOwner() != Owner)
@@ -438,7 +438,7 @@ void movetransports_d(void)
 					}
 					else if (k == 2)
 					{
-						act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+						act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 						act2->backupvec2();
 
 						if (Owner->GetOwner() != Owner)

--- a/source/games/duke/src/actors_r.cpp
+++ b/source/games/duke/src/actors_r.cpp
@@ -198,11 +198,11 @@ int ifhitbyweapon_r(DDukeActor *actor)
 
 				if (adef->flags2 & SFLAG2_DOUBLEDMGTHRUST)
 				{
-					p->vel.XY() += actor->hitang.ToVector() * actor->hitextra * 0.25;
+					p->vel += actor->hitang.ToVector() * actor->hitextra * 0.25;
 				}
 				else
 				{
-					p->vel.XY() += actor->hitang.ToVector() * actor->hitextra * 0.125;
+					p->vel += actor->hitang.ToVector() * actor->hitextra * 0.125;
 				}
 			}
 			else
@@ -312,7 +312,7 @@ void movetransports_r(void)
 						if ((p->jetpack_on == 0) || (p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_JUMP) || p->cmd.ucmd.vel.Z > 0)) ||
 							(p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_CROUCH) || p->cmd.ucmd.vel.Z < 0)))
 						{
-							act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+							act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 							act2->backupvec2();
 
 							if (p->jetpack_on && (!!(p->cmd.ucmd.actions & SB_JUMP) || p->jetpack_on < 11))
@@ -378,7 +378,7 @@ void movetransports_r(void)
 
 					if (k == 1)
 					{
-						act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+						act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 						act2->backupvec2();
 
 						if (!Owner || Owner->GetOwner() != Owner)
@@ -392,7 +392,7 @@ void movetransports_r(void)
 					}
 					else if (k == 2)
 					{
-						act2->spr.pos.XY() += Owner->spr.pos.XY() - act->spr.pos.XY();
+						act2->spr.pos += Owner->spr.pos.XY() - act->spr.pos.XY();
 						act2->backupvec2();
 
 						if (Owner->GetOwner() != Owner)

--- a/source/games/duke/src/animatesprites.cpp
+++ b/source/games/duke/src/animatesprites.cpp
@@ -76,7 +76,7 @@ void drawshadows(tspriteArray& tsprites, tspritetype* t, DDukeActor* h)
 			{
 				// Alter the shadow's position so that it appears behind the sprite itself.
 				auto look = (shadowspr->pos.XY() - spactpos.XY()).Angle();
-				shadowspr->pos.XY() += look.ToVector() * 2;
+				shadowspr->pos += look.ToVector() * 2;
 			}
 		}
 	}

--- a/source/games/duke/src/gameexec.cpp
+++ b/source/games/duke/src/gameexec.cpp
@@ -2010,7 +2010,7 @@ int ParseState::parse(void)
 	case concmd_slapplayer:
 		insptr++;
 		forceplayerangle(p);
-		p->vel.XY() -= pact->spr.Angles.Yaw.ToVector() * 8;
+		p->vel -= pact->spr.Angles.Yaw.ToVector() * 8;
 		return 0;
 	case concmd_wackplayer:
 		insptr++;

--- a/source/games/duke/src/inlines.h
+++ b/source/games/duke/src/inlines.h
@@ -221,7 +221,7 @@ inline int monsterCheatCheck(DDukeActor* self)
 
 inline void rotateInputVel(DDukePlayer* const p)
 {
-	p->cmd.ucmd.vel.XY() = p->cmd.ucmd.vel.XY().Rotated(p->GetActor()->spr.Angles.Yaw) + p->fric;
+	p->cmd.ucmd.vel.SetXY(p->cmd.ucmd.vel.XY().Rotated(p->GetActor()->spr.Angles.Yaw) + p->fric);
 }
 
 inline const ActorInfo* DDukeActor::conInfo() const

--- a/source/games/duke/src/player.cpp
+++ b/source/games/duke/src/player.cpp
@@ -1551,7 +1551,7 @@ void wackplayer(DDukePlayer* p)
 		forceplayerangle(p);
 	else
 	{
-		p->vel.XY() -= p->GetActor()->spr.Angles.Yaw.ToVector() * 64;
+		p->vel -= p->GetActor()->spr.Angles.Yaw.ToVector() * 64;
 		p->jumping_counter = 767;
 		p->jumping_toggle = 1;
 	}

--- a/source/games/duke/src/player_d.cpp
+++ b/source/games/duke/src/player_d.cpp
@@ -1591,7 +1591,7 @@ void processinput_d(DDukePlayer* const p)
 		else if (badguy(clz.actor()) && clz.actor()->spr.scale.X > 0.375 && abs(pact->spr.pos.Z - clz.actor()->spr.pos.Z) < 84)
 		{
 			auto ang = (clz.actor()->spr.pos.XY() - pact->spr.pos.XY()).Angle();
-			p->vel.XY() -= ang.ToVector();
+			p->vel -= ang.ToVector();
 		}
 		CallStandingOn(clz.actor(), p);
 	}
@@ -1772,7 +1772,7 @@ void processinput_d(DDukePlayer* const p)
 		if (p->jetpack_on == 0 && p->steroids_amount > 0 && p->steroids_amount < 400)
 			doubvel <<= 1;
 
-		p->vel.XY() += p->cmd.ucmd.vel.XY() * doubvel * (5. / 16.);
+		p->vel += p->cmd.ucmd.vel.XY() * doubvel * (5. / 16.);
 		p->RollVel += RollVel * doubvel * (5. / 16.);
 
 		bool check;
@@ -1781,19 +1781,19 @@ void processinput_d(DDukePlayer* const p)
 		else check = ((aplWeaponWorksLike(p->curr_weapon, p) == KNEE_WEAPON && p->kickback_pic > 10 && p->on_ground) || (p->on_ground && (actions & SB_CROUCH)));
 		if (check)
 		{
-			p->vel.XY() *= gs.playerfriction - 0.125;
+			p->vel.SetXY(p->vel.XY() * (gs.playerfriction - 0.125));
 			p->RollVel *= gs.playerfriction - 0.125;
 		}
 		else
 		{
 			if (psectlotag == ST_2_UNDERWATER)
 			{
-				p->vel.XY() *= gs.playerfriction - FixedToFloat(0x1400);
+				p->vel.SetXY(p->vel.XY() * (gs.playerfriction - FixedToFloat(0x1400)));
 				p->RollVel *= gs.playerfriction - FixedToFloat(0x1400);
 			}
 			else
 			{
-				p->vel.XY() *= gs.playerfriction;
+				p->vel.SetXY(p->vel.XY() * gs.playerfriction);
 				p->RollVel *= gs.playerfriction;
 			}
 		}
@@ -1806,7 +1806,7 @@ void processinput_d(DDukePlayer* const p)
 
 		if (shrunk)
 		{
-			p->vel.XY() *= gs.playerfriction * 0.75;
+			p->vel.SetXY(p->vel.XY() * (gs.playerfriction * 0.75));
 			p->RollVel *= gs.playerfriction * 0.75;
 		}
 	}
@@ -1823,7 +1823,7 @@ HORIZONLY:
 	Collision clip{};
 	if (ud.clipping)
 	{
-		pact->spr.pos.XY() += p->vel.XY() ;
+		pact->spr.pos += p->vel.XY();
 		updatesector(pact->getPosWithOffsetZ(), &p->cursector);
 		ChangeActorSect(pact, p->cursector);
 	}

--- a/source/games/duke/src/player_r.cpp
+++ b/source/games/duke/src/player_r.cpp
@@ -2992,7 +2992,7 @@ void OffMotorcycle(DDukePlayer *p)
 		p->VBumpTarget = 0;
 		p->VBumpNow = 0;
 		p->TurbCount = 0;
-		p->vel.XY() = pact->spr.Angles.Yaw.ToVector() / 2048.;
+		p->vel.SetXY(pact->spr.Angles.Yaw.ToVector() / 2048.);
 		p->moto_underwater = 0;
 		auto spawned = spawn(pact, RedneckEmptyBikeClass);
 		if (spawned)
@@ -3047,7 +3047,7 @@ void OffBoat(DDukePlayer *p)
 		p->VBumpTarget = 0;
 		p->VBumpNow = 0;
 		p->TurbCount = 0;
-		p->vel.XY() = pact->spr.Angles.Yaw.ToVector() / 2048.;
+		p->vel.SetXY(pact->spr.Angles.Yaw.ToVector() / 2048.);
 		p->moto_underwater = 0;
 		auto spawned = spawn(pact, RedneckEmptyBoatClass);
 		if (spawned)

--- a/source/games/duke/src/player_r.cpp
+++ b/source/games/duke/src/player_r.cpp
@@ -426,7 +426,7 @@ int doincrements_r(DDukePlayer* p)
 		{
 			p->noise_radius = 1024;
 			madenoise(getPlayer(screenpeek));
-			p->vel.XY() += pact->spr.Angles.Yaw.ToVector();
+			p->vel += pact->spr.Angles.Yaw.ToVector();
 		}
 		p->eat -= 4;
 		if (p->eat < 0)
@@ -1032,14 +1032,14 @@ static void onMotorcycle(DDukePlayer* const p, ESyncBits &actions)
 			}
 		}
 
-		p->vel.XY() += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
+		p->vel += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
 		pact->spr.Angles.Yaw -= DAngle::fromBam(angAdjustment);
 	}
 	else if (p->MotoSpeed >= 20 && p->on_ground == 1 && (p->moto_on_mud || p->moto_on_oil))
 	{
 		velAdjustment = krand() & 1 ? adjust : -adjust;
 		currSpeed = MulScale(currSpeed, p->moto_on_oil ? 10 : 5, 7);
-		p->vel.XY() += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
+		p->vel += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
 	}
 
 	p->moto_on_mud = p->moto_on_oil = 0;
@@ -1106,7 +1106,7 @@ static void onBoat(DDukePlayer* const p, ESyncBits &actions)
 			angAdjustment >>= 6;
 		}
 
-		p->vel.XY() += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
+		p->vel += (pact->spr.Angles.Yaw + velAdjustment).ToVector() * currSpeed;
 		pact->spr.Angles.Yaw -= DAngle::fromBam(angAdjustment);
 	}
 	if (p->NotOnWater && p->MotoSpeed > 50)
@@ -1754,7 +1754,7 @@ static void operateweapon(DDukePlayer* const p, ESyncBits actions, sectortype* p
 			p->visibility = 0;
 			if (psectlotag != 857)
 			{
-				p->vel.XY() -= pact->spr.Angles.Yaw.ToVector();
+				p->vel -= pact->spr.Angles.Yaw.ToVector();
 			}
 		}
 		else if (p->kickback_pic == 2)
@@ -1837,12 +1837,12 @@ static void operateweapon(DDukePlayer* const p, ESyncBits actions, sectortype* p
 
 				if (psectlotag != 857)
 				{
-					p->vel.XY() -= pact->spr.Angles.Yaw.ToVector() * 2;
+					p->vel -= pact->spr.Angles.Yaw.ToVector() * 2;
 				}
 			}
 			else if (psectlotag != 857)
 			{
-				p->vel.XY() -= pact->spr.Angles.Yaw.ToVector();
+				p->vel -= pact->spr.Angles.Yaw.ToVector();
 			}
 		}
 
@@ -1928,7 +1928,7 @@ static void operateweapon(DDukePlayer* const p, ESyncBits actions, sectortype* p
 
 				if (psectlotag != 857)
 				{
-					p->vel.XY() -= pact->spr.Angles.Yaw.ToVector();
+					p->vel -= pact->spr.Angles.Yaw.ToVector();
 				}
 				checkavailweapon(p);
 
@@ -2068,7 +2068,7 @@ static void operateweapon(DDukePlayer* const p, ESyncBits actions, sectortype* p
 		}
 		else if (p->kickback_pic == 12)
 		{
-			p->vel.XY() -= pact->spr.Angles.Yaw.ToVector();
+			p->vel -= pact->spr.Angles.Yaw.ToVector();
 			pact->spr.Angles.Pitch -= DAngle::fromDeg(8.88);
 			p->recoil += 20;
 		}
@@ -2115,7 +2115,7 @@ static void operateweapon(DDukePlayer* const p, ESyncBits actions, sectortype* p
 		}
 		if (p->kickback_pic < 30)
 		{
-			p->vel.XY() += pact->spr.Angles.Yaw.ToVector();
+			p->vel += pact->spr.Angles.Yaw.ToVector();
 		}
 		p->kickback_pic++;
 		if (p->kickback_pic > 40)
@@ -2398,7 +2398,7 @@ void processinput_r(DDukePlayer* const p)
 		else if (badguy(clz.actor()) && clz.actor()->spr.scale.X > 0.375 && abs(pact->spr.pos.Z - clz.actor()->spr.pos.Z) < 84)
 		{
 			auto ang = (clz.actor()->spr.pos.XY() - pact->spr.pos.XY()).Angle();
-			p->vel.XY() -= ang.ToVector();
+			p->vel -= ang.ToVector();
 		}
 		if (clz.actor()->GetClass() == RedneckLadderClass)
 		{
@@ -2624,24 +2624,24 @@ void processinput_r(DDukePlayer* const p)
 		if (p->jetpack_on == 0 && p->steroids_amount > 0 && p->steroids_amount < 400)
 			doubvel <<= 1;
 
-		p->vel.XY() += p->cmd.ucmd.vel.XY() * doubvel * (5. / 16.);
+		p->vel += p->cmd.ucmd.vel.XY() * doubvel * (5. / 16.);
 		p->RollVel += RollVel * doubvel * (5. / 16.);
 
 		if (!isRRRA() && ((p->curr_weapon == KNEE_WEAPON && p->kickback_pic > 10 && p->on_ground) || (p->on_ground && (actions & SB_CROUCH))))
 		{
-			p->vel.XY() *= gs.playerfriction - 0.125;
+			p->vel.SetXY(p->vel.XY() * (gs.playerfriction - 0.125));
 			p->RollVel *= gs.playerfriction - 0.125;
 		}
 		else
 		{
 			if (psectlotag == 2)
 			{
-				p->vel.XY() *= gs.playerfriction - FixedToFloat(0x1400);
+				p->vel.SetXY(p->vel.XY() * (gs.playerfriction - FixedToFloat(0x1400)));
 				p->RollVel *= gs.playerfriction - FixedToFloat(0x1400);
 			}
 			else
 			{
-				p->vel.XY() *= gs.playerfriction;
+				p->vel.SetXY(p->vel.XY() * gs.playerfriction);
 				p->RollVel *= gs.playerfriction;
 			}
 		}
@@ -2663,7 +2663,7 @@ void processinput_r(DDukePlayer* const p)
 				p->boot_amount--;
 			else
 			{
-				p->vel.XY() *= gs.playerfriction;
+				p->vel.SetXY(p->vel.XY() * gs.playerfriction);
 				p->RollVel *= gs.playerfriction;
 			}
 		}
@@ -2673,7 +2673,7 @@ void processinput_r(DDukePlayer* const p)
 			{
 				if (p->on_ground)
 				{
-					p->vel.XY() *= gs.playerfriction - FixedToFloat(0x1800);
+					p->vel.SetXY(p->vel.XY() * (gs.playerfriction - FixedToFloat(0x1800)));
 					p->RollVel *= gs.playerfriction - FixedToFloat(0x1800);
 				}
 			}
@@ -2682,7 +2682,7 @@ void processinput_r(DDukePlayer* const p)
 					p->boot_amount--;
 				else
 				{
-					p->vel.XY() *= gs.playerfriction - FixedToFloat(0x1800);
+					p->vel.SetXY(p->vel.XY() * (gs.playerfriction - FixedToFloat(0x1800)));
 					p->RollVel *= gs.playerfriction - FixedToFloat(0x1800);
 				}
 		}
@@ -2695,7 +2695,7 @@ void processinput_r(DDukePlayer* const p)
 
 		if (shrunk)
 		{
-			p->vel.XY() *= gs.playerfriction * 0.75;
+			p->vel.SetXY(p->vel.XY() * (gs.playerfriction * 0.75));
 			p->RollVel *= gs.playerfriction * 0.75;
 		}
 	}
@@ -2715,7 +2715,7 @@ HORIZONLY:
 	Collision clip{};
 	if (ud.clipping)
 	{
-		pact->spr.pos.XY() += p->vel.XY() ;
+		pact->spr.pos += p->vel.XY();
 		updatesector(pact->getPosWithOffsetZ(), &p->cursector);
 		ChangeActorSect(pact, p->cursector);
 	}

--- a/source/games/duke/src/prediction.cpp
+++ b/source/games/duke/src/prediction.cpp
@@ -128,11 +128,11 @@ void fakedomovethings(void)
 
 		if( ud.clipping == 0 && ( psect->floortexture == mirrortex || psect == nullptr) )
 		{
-			mypos.XY() = omypos.XY();
+			mypos.SetXY(omypos.XY());
 		}
 		else
 		{
-			omypos.XY() = mypos.XY();
+			omypos.SetXY(mypos.XY());
 		}
 
 		omyhoriz = myhoriz;

--- a/source/games/duke/src/sectors_d.cpp
+++ b/source/games/duke/src/sectors_d.cpp
@@ -140,7 +140,7 @@ void checkplayerhurt_d(DDukePlayer* p, const Collision& coll)
 			p->hurt_delay = 16;
 			SetPlayerPal(p, PalEntry(32, 32, 0, 0));
 
-			p->vel.XY() = -pact->spr.Angles.Yaw.ToVector() * 16;
+			p->vel.SetXY(-pact->spr.Angles.Yaw.ToVector() * 16);
 			S_PlayActorSound(DUKE_LONGTERM_PAIN, pact);
 
 			checkhitwall(pact, wal, pact->getPosWithOffsetZ() + pact->spr.Angles.Yaw.ToVector() * 2);

--- a/source/games/duke/src/spawn.cpp
+++ b/source/games/duke/src/spawn.cpp
@@ -676,7 +676,7 @@ void spawneffector(DDukeActor* actor, TArray<DDukeActor*>* actors)
 						{
 							if (actor->spr.Angles.Yaw == DAngle90)
 							{
-								actor->spr.pos.XY() = act2->spr.pos.XY();
+								actor->spr.pos.SetXY(act2->spr.pos.XY());
 							}
 							found = true;
 							actor->SetOwner(act2);
@@ -737,7 +737,7 @@ void spawneffector(DDukeActor* actor, TArray<DDukeActor*>* actors)
 
 			else if (actor->spr.lotag == SE_26)
 			{
-				actor->temp_pos.XY() = actor->spr.pos.XY();
+				actor->temp_pos.SetXY(actor->spr.pos.XY());
 				if (actor->spr.shade == sectp->floorshade) //UP
 					actor->vel.Z = -1;
 				else

--- a/source/games/duke/src/types.h
+++ b/source/games/duke/src/types.h
@@ -366,7 +366,7 @@ public:
 		return (117351124. / 10884538.);
 	}
 
-	const DVector2& GetInputVelocity() const override
+	const DVector2 GetInputVelocity() const override
 	{
 		return vel.XY();
 	}

--- a/source/games/exhumed/src/anubis.cpp
+++ b/source/games/exhumed/src/anubis.cpp
@@ -175,7 +175,7 @@ void AIAnubis::Tick(RunListEvent* ev)
         if ((ap->nPhase & 0x1F) == (totalmoves & 0x1F) && pTarget)
         {
             PlotCourseToSprite(ap, pTarget);
-			ap->vel.XY() = ap->spr.Angles.Yaw.ToVector() * 256;
+			ap->vel.SetXY(ap->spr.Angles.Yaw.ToVector() * 256);
         }
 
         switch (move.type)
@@ -264,7 +264,7 @@ void AIAnubis::Tick(RunListEvent* ev)
         if (bVal)
         {
             ap->nAction = 1;
-			ap->vel.XY() = ap->spr.Angles.Yaw.ToVector() * 256;
+			ap->vel.SetXY(ap->spr.Angles.Yaw.ToVector() * 256);
             ap->nFrame = 0;
         }
         else if (seqFrame.flags & 0x80)

--- a/source/games/exhumed/src/bullet.cpp
+++ b/source/games/exhumed/src/bullet.cpp
@@ -248,7 +248,7 @@ void BulletHitsSprite(Bullet *pBullet, DExhumedActor* pBulletActor, DExhumedActo
             {
                 auto nAngle = (pActor->spr.Angles.Yaw + DAngle22_5) - RandomAngle9();
 
-				pHitActor->vel.XY() = nAngle.ToVector() * 2048;
+				pHitActor->vel.SetXY(nAngle.ToVector() * 2048);
                 pHitActor->vel.Z = -(RandomSize(3) + 1);
             }
             else
@@ -257,7 +257,7 @@ void BulletHitsSprite(Bullet *pBullet, DExhumedActor* pBulletActor, DExhumedActo
                 pHitActor->VelFromAngle(-2);
 
                 MoveCreature(pHitActor);
-				pHitActor->vel.XY() = Vel;
+				pHitActor->vel.SetXY(Vel);
             }
 
             break;
@@ -769,7 +769,7 @@ DExhumedActor* BuildBullet(DExhumedActor* pActor, int nType, double fZOffset, DA
     }
 
     pBullet->vect.Z = 0;
-    pBullet->vect.XY() = nAngle.ToVector() * pActor->clipdist;
+    pBullet->vect.SetXY(nAngle.ToVector() * pActor->clipdist);
     BulletList[nBullet].pEnemy = nullptr;
 
 
@@ -780,7 +780,7 @@ DExhumedActor* BuildBullet(DExhumedActor* pActor, int nType, double fZOffset, DA
     else
     {
         pBullet->field_10 = pBulletInfo->field_4;
-		pBullet->vect.XY() = nAngle.ToVector() * pBulletInfo->field_4 / 128.;
+		pBullet->vect.SetXY(nAngle.ToVector() * pBulletInfo->field_4 / 128.);
         pBullet->vect.Z = nVertVel * 0.125;
     }
 

--- a/source/games/exhumed/src/exhumedactor.h
+++ b/source/games/exhumed/src/exhumedactor.h
@@ -50,7 +50,7 @@ public:
 	void Serialize(FSerializer& arc) override;
 	void VelFromAngle(int shift = 0)
 	{
-		vel.XY() = spr.Angles.Yaw.ToVector() * (1 << (10 + shift));
+		vel.SetXY(spr.Angles.Yaw.ToVector() * (1 << (10 + shift)));
 	}
 
 

--- a/source/games/exhumed/src/fish.cpp
+++ b/source/games/exhumed/src/fish.cpp
@@ -423,7 +423,7 @@ void AIFish::Tick(RunListEvent* ev)
 
             if (z <= nHeight)
             {
-				pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * (32 - 8);
+				pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * (32 - 8));
             }
             else
             {

--- a/source/games/exhumed/src/lion.cpp
+++ b/source/games/exhumed/src/lion.cpp
@@ -275,11 +275,11 @@ void AILion::Tick(RunListEvent* ev)
 
             if (pActor->spr.cstat & CSTAT_SPRITE_INVISIBLE)
             {
-				pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * 2048;
+				pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * 2048);
             }
             else
             {
-				pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * 512;
+				pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * 512);
             }
         }
 
@@ -403,7 +403,7 @@ void AILion::Tick(RunListEvent* ev)
             pActor->spr.Angles.Yaw = nAngle;
             pActor->nFrame = 0;
             pActor->nAction = 6;
-			pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * (1024 - 128);
+			pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * (1024 - 128));
 			D3PlayFX(StaticSound[kSound24], pActor);
         }
 
@@ -469,7 +469,7 @@ void AILion::Tick(RunListEvent* ev)
             pActor->vel.Z = -1000 / 256.;
             pActor->nFrame = 0;
             pActor->nAction = 6;
-			pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * (1024 - 128);
+			pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * (1024 - 128));
             D3PlayFX(StaticSound[kSound24], pActor);
         }
 

--- a/source/games/exhumed/src/move.cpp
+++ b/source/games/exhumed/src/move.cpp
@@ -473,7 +473,7 @@ Collision movesprite(DExhumedActor* pActor, DVector2 vect, double dz, double flo
 
         if ((pSector->floorz - spos.Z) < (dz + flordist))
         {
-			pActor->spr.pos.XY() = spos.XY();
+			pActor->spr.pos.SetXY(spos.XY());
         }
         else
         {
@@ -776,7 +776,7 @@ void MoveSector(sectortype* pSector, DAngle nAngle, DVector2& nVel)
 
     DVector3 pos;
 
-    pos.XY() = sBlockInfo[nBlock].pos;
+    pos.SetXY(sBlockInfo[nBlock].pos);
     auto b_pos = pos.XY();
 
     double nZVal;
@@ -812,7 +812,7 @@ void MoveSector(sectortype* pSector, DAngle nAngle, DVector2& nVel)
     {
         if (!bUnderwater)
         {
-            pos.XY() = b_pos;
+            pos.SetXY(b_pos);
             pos.Z = nZVal;
 
             clipmove(pos, &pSectorB, nVect, pBlockInfo->mindist, 0., 0., CLIPMASK1, scratch);
@@ -847,7 +847,7 @@ void MoveSector(sectortype* pSector, DAngle nAngle, DVector2& nVel)
 
                 if ((nSectFlag & kSectUnderwater) || pos.Z != nZVal || pActor->spr.cstat & CSTAT_SPRITE_INVISIBLE)
                 {
-                    pos.XY() = pActor->spr.pos.XY();
+                    pos.SetXY(pActor->spr.pos.XY());
                     pSectorB = pSector;
 
                     // The vector that got passed in here originally was Q28.4, while clipmove expects Q14.18, effectively resulting in actual zero movement
@@ -1270,7 +1270,7 @@ void AICreatureChunk::Tick(RunListEvent* ev)
 			double nSqrt = pActor->vel.Length();
 
 
-			pActor->vel.XY() = nAngle.ToVector() * nSqrt * 0.5;
+			pActor->vel.SetXY(nAngle.ToVector() * nSqrt * 0.5);
             return;
         }
     }

--- a/source/games/exhumed/src/object.cpp
+++ b/source/games/exhumed/src/object.cpp
@@ -1388,7 +1388,7 @@ DExhumedActor* BuildSpark(DExhumedActor* pActor, int nVal)
 {
     auto pSpark = insertActor(pActor->sector(), 0);
 
-    pSpark->spr.pos.XY() = pActor->spr.pos.XY();
+    pSpark->spr.pos.SetXY(pActor->spr.pos.XY());
     pSpark->spr.cstat = 0;
     pSpark->spr.shade = -127;
     pSpark->spr.pal = 1;
@@ -1416,11 +1416,11 @@ DExhumedActor* BuildSpark(DExhumedActor* pActor, int nVal)
 
         if (nVal)
         {
-			pSpark->vel.XY() = nAngle.ToVector() * 32;
+			pSpark->vel.SetXY(nAngle.ToVector() * 32);
         }
         else
         {
-			pSpark->vel.XY() = nAngle.ToVector() * 16;
+			pSpark->vel.SetXY(nAngle.ToVector() * 16);
         }
 
         pSpark->vel.Z = -RandomSize(4) * 0.5;
@@ -1620,7 +1620,7 @@ DExhumedActor* BuildEnergyBlock(sectortype* pSector)
 
     auto pActor = insertActor(pSector, 406);
 
-	pActor->spr.pos.XY() = apos / pSector->walls.Size();
+	pActor->spr.pos.SetXY(apos / pSector->walls.Size());
 
     pSector->extra = (int16_t)EnergyBlocks.Push(pActor);
 

--- a/source/games/exhumed/src/object.cpp
+++ b/source/games/exhumed/src/object.cpp
@@ -1984,7 +1984,7 @@ void AIObject::Tick(RunListEvent* ev)
 
             if (nMov.exbits & kHitAux2)
             {
-				pActor->vel.XY() *= 0.875;
+				pActor->vel.SetXY(pActor->vel.XY() * 0.875);
             }
 
             if (nMov.type == kHitSprite)

--- a/source/games/exhumed/src/player.cpp
+++ b/source/games/exhumed/src/player.cpp
@@ -436,7 +436,7 @@ void SetPlayerMummified(DExhumedPlayer* const pPlayer, int bIsMummified)
 {
     const auto pPlayerActor = pPlayer->GetActor();
 
-    pPlayerActor->vel.XY().Zero();
+    pPlayerActor->vel.SetXY(DVector2(0, 0));
 
     if ((pPlayer->bIsMummified = bIsMummified))
     {
@@ -1092,8 +1092,7 @@ static void updatePlayerVelocity(DExhumedPlayer* const pPlayer)
 
         for (int i = 0; i < 4; i++)
         {
-            pPlayerActor->vel.XY() += inputvect;
-            pPlayerActor->vel.XY() *= 0.953125;
+            pPlayerActor->vel.SetXY((pPlayerActor->vel.XY() + inputvect) * 0.953125);
             pPlayer->RollVel += pInput->vel.Y * 0.375;
             pPlayer->RollVel *= 0.953125;
         }
@@ -1101,7 +1100,7 @@ static void updatePlayerVelocity(DExhumedPlayer* const pPlayer)
 
     if (pPlayerActor->vel.XY().Length() < 0.09375 && !pPlayerActor->vel.XY().isZero())
     {
-        pPlayerActor->vel.XY().Zero();
+        pPlayerActor->vel.SetXY(DVector2(0, 0));
         pPlayer->nIdxBobZ = 0;
         pPlayer->RollVel = 0;
     }
@@ -1669,7 +1668,7 @@ static void doPlayerFloorDamage(DExhumedPlayer* const pPlayer, const double nSta
     if (nStartVelZ < (6500 / 256.))
         return;
 
-    pPlayerActor->vel.XY() *= 0.25;
+    pPlayerActor->vel.SetXY(pPlayerActor->vel.XY() * 0.25);
     runlist_DamageEnemy(pPlayerActor, nullptr, int(((nStartVelZ * 256) - 6500) * (1. / 128.)) + 10);
 
     if (pPlayer->nHealth <= 0)

--- a/source/games/exhumed/src/player.cpp
+++ b/source/games/exhumed/src/player.cpp
@@ -243,7 +243,7 @@ void RestartPlayer(DExhumedPlayer* const pPlayer)
 	}
 	else
 	{
-        pPlayerActor->spr.pos.XY() = pPlayer->sPlayerSave.pos.XY();
+        pPlayerActor->spr.pos.SetXY(pPlayer->sPlayerSave.pos.XY());
 		pPlayerActor->spr.pos.Z = pPlayer->sPlayerSave.pSector->floorz;
 		pPlayerActor->spr.Angles.Yaw = pPlayer->sPlayerSave.nAngle;
         ChangeActorSect(pPlayerActor, pPlayer->sPlayerSave.pSector);
@@ -1584,7 +1584,7 @@ static void updatePlayerFloorActor(DExhumedPlayer* const pPlayer)
 
     const auto pPlayerActor = pPlayer->GetActor();
     const auto pPlayerSect = pPlayerActor->sector();
-    pFloorActor->spr.pos.XY() = pPlayerActor->spr.pos.XY();
+    pFloorActor->spr.pos.SetXY(pPlayerActor->spr.pos.XY());
     pFloorActor->spr.pos.Z = pPlayerSect->floorz;
 
     if (pFloorActor->sector() != pPlayerSect)
@@ -1785,7 +1785,7 @@ static bool doPlayerInput(DExhumedPlayer* const pPlayer)
         if (inside(pPlayerActor->spr.pos.X, pPlayerActor->spr.pos.Y, pPlayerActor->sector()) != 1)
         {
             ChangeActorSect(pPlayerActor, spr_sect);
-            pPlayerActor->spr.pos.XY() = pPlayerActor->opos.XY();
+            pPlayerActor->spr.pos.SetXY(pPlayerActor->opos.XY());
 
             if (nStartVelZ < pPlayerActor->vel.Z)
                 pPlayerActor->vel.Z = nStartVelZ;

--- a/source/games/exhumed/src/queen.cpp
+++ b/source/games/exhumed/src/queen.cpp
@@ -312,7 +312,7 @@ void DestroyAllEggs()
 
 void SetHeadVel(DExhumedActor* pActor)
 {
-	pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * (1 << nVelShift);
+	pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * (1 << nVelShift));
 }
 
 //---------------------------------------------------------------------------
@@ -482,7 +482,7 @@ void BuildQueenEgg(int nQueen, int nVal)
     if (!nVal)
     {
 		pActor2->spr.scale = DVector2(0.46875, 0.46875);
-		pActor2->vel.XY() = pActor2->spr.Angles.Yaw.ToVector();
+		pActor2->vel.SetXY(pActor2->spr.Angles.Yaw.ToVector());
         pActor2->vel.Z = -6000 / 256.;
         pActor2->spr.cstat = 0;
     }
@@ -613,7 +613,7 @@ void AIQueenEgg::Tick(RunListEvent* ev)
             }
 
             pActor->spr.Angles.Yaw = nAngle;
-			pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * 0.5;
+			pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * 0.5);
         }
 
         break;
@@ -750,7 +750,7 @@ void BuildQueenHead(int nQueen)
 
     auto pActor2 = insertActor(pSector, 121);
 
-	pActor2->spr.pos.XY() = pActor->spr.pos.XY();
+	pActor2->spr.pos.SetXY(pActor->spr.pos.XY());
 	pActor2->spr.pos.Z = pSector->floorz;
 	pActor2->clipdist = 17.5;
 	pActor2->spr.scale = DVector2(1.25, 1.25);

--- a/source/games/exhumed/src/rex.cpp
+++ b/source/games/exhumed/src/rex.cpp
@@ -281,7 +281,7 @@ void AIRex::Tick(RunListEvent* ev)
             {
                 if ((PlotCourseToSprite(pActor, pTarget) >= 60*16) || pActor->nCount > 0)
                 {
-					pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * 256;
+					pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * 256);
                 }
                 else
                 {
@@ -369,7 +369,7 @@ void AIRex::Tick(RunListEvent* ev)
                     }
                     else
                     {
-						pHitActor->vel.XY() = vel / 8.;
+						pHitActor->vel.SetXY(vel / 8.);
                         pHitActor->vel.Z = 11.25;
                     }
                 }

--- a/source/games/exhumed/src/roach.cpp
+++ b/source/games/exhumed/src/roach.cpp
@@ -103,7 +103,7 @@ void BuildRoach(int nType, DExhumedActor* pActor, const DVector3& pos, sectortyp
 
 void GoRoach(DExhumedActor* pActor)
 {
-	pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * (512 - 128);
+	pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * (512 - 128));
 }
 
 void AIRoach::Draw(RunListEvent* ev)

--- a/source/games/exhumed/src/scorp.cpp
+++ b/source/games/exhumed/src/scorp.cpp
@@ -402,7 +402,7 @@ void AIScorp::Tick(RunListEvent* ev)
 
             int nVel = RandomSize(5) + 1;
 
-			pSpiderActor->vel.XY() = pSpiderActor->spr.Angles.Yaw.ToVector() * 4 * nVel;
+			pSpiderActor->vel.SetXY(pSpiderActor->spr.Angles.Yaw.ToVector() * 4 * nVel);
             pSpiderActor->vel.Z = -(RandomSize(5) + 3);
         }
 

--- a/source/games/exhumed/src/set.cpp
+++ b/source/games/exhumed/src/set.cpp
@@ -430,7 +430,7 @@ void AISet::Tick(RunListEvent* ev)
             }
 
             // loc_338E2
-			pActor->vel.XY() = pActor->spr.Angles.Yaw.ToVector() * 512;
+			pActor->vel.SetXY(pActor->spr.Angles.Yaw.ToVector() * 512);
 
             if (pActor->nIndex2)
             {

--- a/source/games/sw/src/break.cpp
+++ b/source/games/sw/src/break.cpp
@@ -738,7 +738,7 @@ int WallBreakPosition(walltype* wp, sectortype** sectp, DVector3& pos, DAngle& a
     ASSERT(*sectp);
 
     // midpoint of wall
-    pos.XY() = wp->center();
+    pos.SetXY(wp->center());
 
     if (!wp->twoSided())
     {

--- a/source/games/sw/src/break.cpp
+++ b/source/games/sw/src/break.cpp
@@ -767,7 +767,7 @@ int WallBreakPosition(walltype* wp, sectortype** sectp, DVector3& pos, DAngle& a
 
     ang = wall_ang;
 
-    pos.XY() += wall_ang.ToVector() * 16;
+    pos += wall_ang.ToVector() * 16;
 
     updatesectorz(pos, sectp);
     if (*sectp == nullptr)

--- a/source/games/sw/src/bunny.cpp
+++ b/source/games/sw/src/bunny.cpp
@@ -1044,7 +1044,7 @@ int DoBunnyQuickJump(DSWActor* actor)
                     }
                 }
 
-                actor->spr.pos.XY() = hitActor->spr.pos.XY();
+                actor->spr.pos.SetXY(hitActor->spr.pos.XY());
                 actor->spr.Angles.Yaw = hitActor->spr.Angles.Yaw;
                 actor->spr.Angles.Yaw += DAngle180;
                 HelpMissileLateral(actor, 2000);

--- a/source/games/sw/src/copysect.cpp
+++ b/source/games/sw/src/copysect.cpp
@@ -182,7 +182,7 @@ void CopySectorMatch(int match)
                         auto src_off = spos.XY() - itActor->spr.pos.XY();
 
                         // move sprite to dest sector
-                        itActor->spr.pos.XY() = dpos.XY() - src_off;
+                        itActor->spr.pos.SetXY(dpos.XY() - src_off);
 
                         // change sector
                         ChangeActorSect(itActor, dsectp);

--- a/source/games/sw/src/draw.cpp
+++ b/source/games/sw/src/draw.cpp
@@ -363,7 +363,7 @@ void DoShadows(tspriteArray& tsprites, tspritetype* tsp, double viewz)
     {
         // Alter the shadow's position so that it appears behind the sprite itself.
         auto look = (tSpr->pos.XY() - getPlayer(screenpeek)->CameraPos.XY()).Angle();
-		tSpr->pos.XY() += look.ToVector() * 2;
+		tSpr->pos += look.ToVector() * 2;
     }
 
     // Check for voxel items and use a round generic pic if so
@@ -790,7 +790,7 @@ static void analyzesprites(tspriteArray& tsprites, const DVector3& viewpos, doub
                     if (pp->Flags & (PF_CLIMBING))
                     {
                         // move sprite forward some so he looks like he's climbing
-                        pos.XY() += tsp->Angles.Yaw.ToVector() * 13;
+                        pos += tsp->Angles.Yaw.ToVector() * 13;
                         pos.Z -= PLAYER_HEIGHTF - 17.;
                     }
 

--- a/source/games/sw/src/draw.cpp
+++ b/source/games/sw/src/draw.cpp
@@ -401,8 +401,10 @@ void DoMotionBlur(tspriteArray& tsprites, tspritetype const * const tsp)
         z_amt_per_pixel = -ownerActor->vel.Z / tsp->ownerActor->vel.X;
     }
 
-    dpos.XY() = npos.XY() = angle.ToVector() * ownerActor->user.motion_blur_dist;
-    dpos.Z = npos.Z = z_amt_per_pixel * ownerActor->user.motion_blur_dist * (1./16);
+    dpos = npos = DVector3(
+        angle.ToVector() * ownerActor->user.motion_blur_dist,
+        z_amt_per_pixel * ownerActor->user.motion_blur_dist * (1. / 16)
+    );
 
 	scale = tsp->scale;
 

--- a/source/games/sw/src/game.h
+++ b/source/games/sw/src/game.h
@@ -1831,7 +1831,7 @@ public:
         return (380401538. / 36022361.);
     }
 
-    const DVector2& GetInputVelocity() const override
+    const DVector2 GetInputVelocity() const override
     {
         return vect;
     }

--- a/source/games/sw/src/jsector.cpp
+++ b/source/games/sw/src/jsector.cpp
@@ -473,7 +473,7 @@ void JS_DrawCameras(DSWPlayer* pp, const DVector3& campos, double smoothratio)
                 // Finish finding offsets
                 DVector3 dpos;
                 DVector3 tdpos;
-                tdpos.XY() = mid - campos;
+                tdpos.SetXY(mid - campos);
 
                 if (mid.X >= campos.X)
                     dpos.X = camactor->spr.pos.X - campos.X;

--- a/source/games/sw/src/jweapon.cpp
+++ b/source/games/sw/src/jweapon.cpp
@@ -459,7 +459,7 @@ int DoBloodSpray(DSWActor* actor)
                 actor->user.change.X = actor->user.change.Y = 0;
                 double scale = (70 - RandomRange(25)) * REPEAT_SCALE;
                 actor->spr.scale = DVector2(scale, scale);
-                actor->spr.pos.XY() = bldActor->spr.pos.XY();
+                actor->spr.pos.SetXY(bldActor->spr.pos.XY());
 
                 // !FRANK! bit of a hack
                 // yvel is the hit_wall
@@ -1209,7 +1209,7 @@ int SpawnRadiationCloud(DSWActor* actor)
     if (actor->user.ID == MUSHROOM_CLOUD || actor->user.ID == 3121)
     {
         actorNew->user.Radius = 2000;
-        actorNew->user.change.XY() = actorNew->spr.Angles.Yaw.ToVector() * actorNew->vel.X * 0.25;
+        actorNew->user.change.SetXY(actorNew->spr.Angles.Yaw.ToVector() * actorNew->vel.X * 0.25);
 		actorNew->vel.Z = 1 + RandomRangeF(2);
     }
     else

--- a/source/games/sw/src/jweapon.cpp
+++ b/source/games/sw/src/jweapon.cpp
@@ -1230,7 +1230,7 @@ int SpawnRadiationCloud(DSWActor* actor)
 
 int DoRadiationCloud(DSWActor* actor)
 {
-	actor->spr.pos.XY() += actor->user.change.XY();
+	actor->spr.pos += actor->user.change.XY();
     actor->spr.pos.Z -= actor->vel.Z;
 
     if (actor->user.ID)

--- a/source/games/sw/src/mclip.cpp
+++ b/source/games/sw/src/mclip.cpp
@@ -73,10 +73,10 @@ Collision MultiClipMove(DSWPlayer* pp, double zz, double floordist)
             min_dist = 0;
             min_ndx = i;
             // ox is where it should be
-            opos[i].XY() = pp->GetActor()->spr.pos.XY() + ang.ToVector() * sop->clipbox_vdist[i];
+            opos[i].SetXY(pp->GetActor()->spr.pos.XY() + ang.ToVector() * sop->clipbox_vdist[i]);
 
             // spos.x is where it hit
-            pos[i].XY() = spos.XY();
+            pos[i].SetXY(spos.XY());
 
             // see the dist moved
             dist = (pos[i].XY() - opos[i].XY()).Length();

--- a/source/games/sw/src/mclip.cpp
+++ b/source/games/sw/src/mclip.cpp
@@ -111,7 +111,7 @@ Collision MultiClipMove(DSWPlayer* pp, double zz, double floordist)
     }
 
     // put posx and y off from offset
-    pp->GetActor()->spr.pos.XY() += pos[min_ndx].XY() - opos[min_ndx].XY();
+    pp->GetActor()->spr.pos += pos[min_ndx].XY() - opos[min_ndx].XY();
 
     return min_ret;
 }
@@ -207,7 +207,7 @@ int RectClipMove(DSWPlayer* pp, DVector2* qpos)
     //Given the 4 points: x[4], y[4]
     if (testquadinsect(&point_num, xy, pp->cursector))
     {
-        pp->GetActor()->spr.pos.XY() += pvect;
+        pp->GetActor()->spr.pos += pvect;
         return true;
     }
 
@@ -223,7 +223,7 @@ int RectClipMove(DSWPlayer* pp, DVector2* qpos)
         }
         if (testquadinsect(&point_num, xy, pp->cursector))
         {
-            pp->GetActor()->spr.pos.XY() += { -pvect.X * 0.5, pvect.X * 0.5 };
+            pp->GetActor()->spr.pos += { -pvect.X * 0.5, pvect.X * 0.5 };
         }
 
         return false;
@@ -238,7 +238,7 @@ int RectClipMove(DSWPlayer* pp, DVector2* qpos)
         }
         if (testquadinsect(&point_num, xy, pp->cursector))
         {
-            pp->GetActor()->spr.pos.XY() += { pvect.X * 0.5, -pvect.X * 0.5 };
+            pp->GetActor()->spr.pos += { pvect.X * 0.5, -pvect.X * 0.5 };
         }
 
         return false;

--- a/source/games/sw/src/player.cpp
+++ b/source/games/sw/src/player.cpp
@@ -3224,7 +3224,7 @@ void DoPlayerClimb(DSWPlayer* pp)
                 if (fabs(ppos.Y - pp->LadderPosition.Y) <= ADJ_AMT)
                     ppos.Y = pp->LadderPosition.Y;
             }
-            plActor->spr.pos.XY() = ppos;
+            plActor->spr.pos.SetXY(ppos);
         }
     }
 
@@ -4060,10 +4060,10 @@ void DoPlayerWarpToUnderwater(DSWPlayer* pp)
     PRODUCTION_ASSERT(Found == true);
 
     // get the offset from the sprite
-    plActor->user.pos.XY() = over_act->spr.pos.XY() - pp->GetActor()->spr.pos.XY();
+    plActor->user.pos.SetXY(over_act->spr.pos.XY() - pp->GetActor()->spr.pos.XY());
 
     // update to the new x y position
-    pp->GetActor()->spr.pos.XY() = under_act->spr.pos.XY() - plActor->user.pos.XY();
+    pp->GetActor()->spr.pos.SetXY(under_act->spr.pos.XY() - plActor->user.pos.XY());
 
     auto over  = over_act->sector();
     auto under = under_act->sector();
@@ -4132,10 +4132,10 @@ void DoPlayerWarpToSurface(DSWPlayer* pp)
     PRODUCTION_ASSERT(Found == true);
 
     // get the offset from the under sprite
-    plActor->user.pos.XY() = under_act->spr.pos.XY() - pp->GetActor()->spr.pos.XY();
+    plActor->user.pos.SetXY(under_act->spr.pos.XY() - pp->GetActor()->spr.pos.XY());
 
     // update to the new x y position
-    pp->GetActor()->spr.pos.XY() = over_act->spr.pos.XY() - plActor->user.pos.XY();
+    pp->GetActor()->spr.pos.SetXY(over_act->spr.pos.XY() - plActor->user.pos.XY());
 
     auto over = over_act->sector();
     auto under = under_act->sector();
@@ -5029,7 +5029,7 @@ void DoPlayerBeginOperate(DSWPlayer* pp)
     sop->controller = pp->GetActor();
 
     pp->GetActor()->PrevAngles.Yaw = pp->GetActor()->spr.Angles.Yaw = sop->ang;
-    pp->GetActor()->spr.pos.XY() = sop->pmid.XY();
+    pp->GetActor()->spr.pos.SetXY(sop->pmid.XY());
     updatesector(pp->GetActor()->getPosWithOffsetZ(), &pp->cursector);
     calcSlope(pp->cursector, pp->GetActor()->getPosWithOffsetZ(), &cz, &fz);
     pp->posZset(fz - PLAYER_HEIGHTF);
@@ -5119,7 +5119,7 @@ void DoPlayerBeginRemoteOperate(DSWPlayer* pp, SECTOR_OBJECT* sop)
     auto save_sect = pp->cursector;
 
     pp->GetActor()->PrevAngles.Yaw = pp->GetActor()->spr.Angles.Yaw = sop->ang;
-    pp->GetActor()->spr.pos.XY() = sop->pmid.XY();
+    pp->GetActor()->spr.pos.SetXY(sop->pmid.XY());
     updatesector(pp->GetActor()->getPosWithOffsetZ(), &pp->cursector);
     calcSlope(pp->cursector, pp->GetActor()->getPosWithOffsetZ(), &cz, &fz);
     pp->posZset(fz - PLAYER_HEIGHTF);
@@ -5205,7 +5205,7 @@ void PlayerRemoteReset(DSWPlayer* pp, sectortype* sect)
     pp->lastcursector = pp->cursector;
 
     auto rsp = pp->remoteActor;
-    pp->GetActor()->spr.pos.XY() = rsp->spr.pos.XY();
+    pp->GetActor()->spr.pos.SetXY(rsp->spr.pos.XY());
     pp->posZset(sect->floorz - PLAYER_HEIGHTF);
 
     pp->vect.Zero();
@@ -6073,7 +6073,7 @@ void DoPlayerDeathMoveHead(DSWPlayer* pp)
         }
     }
 
-    pp->GetActor()->spr.pos.XY() = plActor->spr.pos.XY();
+    pp->GetActor()->spr.pos.SetXY(plActor->spr.pos.XY());
     pp->setcursector(plActor->sector());
 
     // try to stay in valid area - death sometimes throws you out of the map
@@ -6083,13 +6083,13 @@ void DoPlayerDeathMoveHead(DSWPlayer* pp)
     {
         pp->cursector = pp->lv_sector;
         ChangeActorSect(pp->GetActor(), pp->lv_sector);
-        pp->GetActor()->spr.pos.XY() = pp->lv.XY();
-		plActor->spr.pos.XY() = pp->GetActor()->spr.pos.XY();
+        pp->GetActor()->spr.pos.SetXY(pp->lv.XY());
+        plActor->spr.pos.SetXY(pp->GetActor()->spr.pos.XY());
     }
     else
     {
         pp->lv_sector = sect;
-        pp->lv.XY() = pp->GetActor()->spr.pos.XY();
+        pp->lv.SetXY(pp->GetActor()->spr.pos.XY());
     }
 }
 
@@ -6870,7 +6870,7 @@ void domovethings(void)
 
         // convert fvel/svel into a vector before performing actions.
         pp->cmd.ucmd.vel.X += pp->cmd.ucmd.vel.Z * (pp->DoPlayerAction == DoPlayerClimb);
-        pp->cmd.ucmd.vel.XY() = pp->cmd.ucmd.vel.XY().Rotated(pp->GetActor()->spr.Angles.Yaw);
+        pp->cmd.ucmd.vel.SetXY(pp->cmd.ucmd.vel.XY().Rotated(pp->GetActor()->spr.Angles.Yaw));
 
         if (pp->DoPlayerAction) pp->DoPlayerAction(pp);
 

--- a/source/games/sw/src/player.cpp
+++ b/source/games/sw/src/player.cpp
@@ -2001,7 +2001,7 @@ void DoPlayerMove(DSWPlayer* pp)
         {
             actor->backupvec2();
         }
-		actor->spr.pos.XY() += pp->vect;
+		actor->spr.pos += pp->vect;
         updatesector(pp->GetActor()->getPosWithOffsetZ(), &sect);
         if (sect != nullptr)
             pp->cursector = sect;

--- a/source/games/sw/src/quake.cpp
+++ b/source/games/sw/src/quake.cpp
@@ -227,7 +227,7 @@ void QuakeViewChange(DSWPlayer* pp, DVector3& tpos, DAngle& tang)
     tangdiff = mapangle(StdRandomRange(ang_amt) - (ang_amt/2));
 
     int pos_amt = QUAKE_PosAmt(actor) * 4L;
-    tposdiff.XY() = DVector2(StdRandomRange(pos_amt) - (pos_amt/2), StdRandomRange(pos_amt) - (pos_amt/2)) * (1. / 4.);
+    tposdiff.SetXY(DVector2(StdRandomRange(pos_amt) - (pos_amt/2), StdRandomRange(pos_amt) - (pos_amt/2)) * (1. / 4.));
 
     if (!QUAKE_TestDontTaper(actor))
     {

--- a/source/games/sw/src/rooms.cpp
+++ b/source/games/sw/src/rooms.cpp
@@ -168,7 +168,7 @@ void FAFhitscan(const DVector3& start, sectortype* sect, const DVector3& vect, H
         if ((hit.hitWall->cstat & CSTAT_WALL_WARP_HITSCAN))
         {
             // back it up a bit to get a correct warp location
-            hit.hitpos.XY() -= vect.XY() * (1 / 512.);
+            hit.hitpos -= vect.XY() * (1 / 512.);
 
             // warp to new x,y,z, sectnum
             if (Warp(hit.hitpos, &hit.hitSector))

--- a/source/games/sw/src/rooms.cpp
+++ b/source/games/sw/src/rooms.cpp
@@ -277,7 +277,7 @@ bool FAFcansee(const DVector3& start, sectortype* sects, const DVector3& end, se
     DVector3 diff = end - start;
     DAngle ang = diff.Angle();
     DVector3 vect; 
-    vect.XY() = ang.ToVector() * 1024;
+    vect.SetXY(ang.ToVector() * 1024);
     double dist = diff.XY().Length();
 
     // get x,y,z, vectors

--- a/source/games/sw/src/sector.cpp
+++ b/source/games/sw/src/sector.cpp
@@ -894,7 +894,7 @@ void SectorExp(DSWActor* actor, sectortype* sectp, double zh)
 
     exp->spr.scale.X += (((RANDOM_P2(32 << 8) >> 8) - 16) * REPEAT_SCALE);
     exp->spr.scale.Y += (((RANDOM_P2(32 << 8) >> 8) - 16) * REPEAT_SCALE);
-    exp->user.change.XY() = exp->spr.Angles.Yaw.ToVector(5.75);
+    exp->user.change.SetXY(exp->spr.Angles.Yaw.ToVector(5.75));
 }
 
 

--- a/source/games/sw/src/skel.cpp
+++ b/source/games/sw/src/skel.cpp
@@ -556,7 +556,7 @@ int DoSkelTeleport(DSWActor* actor)
 
     while (true)
     {
-        pos.XY() = actor->spr.pos.XY();
+        pos.SetXY(actor->spr.pos.XY());
 
         if (RANDOM_P2(1024) < 512)
             pos.X += 32 + RANDOM_P2F(64, 4);

--- a/source/games/sw/src/sprite.cpp
+++ b/source/games/sw/src/sprite.cpp
@@ -3765,7 +3765,7 @@ int ActorCoughItem(DSWActor* actor)
         actorNew = insertActor(actor->sector(), STAT_SPAWN_ITEMS);
         actorNew->spr.cstat = 0;
         actorNew->spr.extra = 0;
-        actorNew->spr.pos.XY() = actor->spr.pos.XY();
+        actorNew->spr.pos.SetXY(actor->spr.pos.XY());
         actorNew->spr.pos.Z = ActorLowerZ(actor) + 10;
         actorNew->spr.Angles.Yaw = actor->spr.Angles.Yaw;
 
@@ -6328,7 +6328,7 @@ Collision move_sprite(DSWActor* actor, const DVector3& change, double ceildist, 
     clipmove(clip_pos, &dasect, change.XY() * numtics * 0.125, actor->clipdist, ceildist, flordist, cliptype, retval, 1);
 
 
-    actor->spr.pos.XY() = clip_pos.XY();
+    actor->spr.pos.SetXY(clip_pos.XY());
 
     if (dasect == nullptr)
     {
@@ -6545,7 +6545,7 @@ Collision move_missile(DSWActor* actor, const DVector3& change, double ceil_dist
 
 
     clipmove(clip_pos, &dasect, change.XY() * numtics * 0.125, actor->clipdist, ceil_dist, flor_dist, cliptype, retval, 1);
-    actor->spr.pos.XY() = clip_pos.XY();
+    actor->spr.pos.SetXY(clip_pos.XY());
 
     if (dasect == nullptr)
     {
@@ -6694,7 +6694,7 @@ Collision move_ground_missile(DSWActor* actor, const DVector2& change, double ce
         opos = actor->spr.pos;
         opos.Z = daz;
         clipmove(opos, &dasect, change * numtics * 0.125, actor->clipdist, ceildist, flordist, cliptype, retval, 1);
-		actor->spr.pos.XY() = opos.XY();
+		actor->spr.pos.SetXY(opos.XY());
     }
 
     if (dasect == nullptr)

--- a/source/games/sw/src/swactor.h
+++ b/source/games/sw/src/swactor.h
@@ -39,7 +39,7 @@ public:
 
 inline void UpdateChangeXY(DSWActor* actor)
 {
-	actor->user.change.XY() = actor->spr.Angles.Yaw.ToVector() * actor->vel.X;
+	actor->user.change.SetXY(actor->spr.Angles.Yaw.ToVector() * actor->vel.X);
 }
 
 inline void UpdateChange(DSWActor* actor, double zfactor = 1.0)

--- a/source/games/sw/src/track.cpp
+++ b/source/games/sw/src/track.cpp
@@ -1487,7 +1487,7 @@ void MovePlayer(DSWPlayer* pp, SECTOR_OBJECT* sop, const DVector2& move)
         pp->RevolveDeltaAng = nullAngle;
     }
 
-    pp->GetActor()->spr.pos.XY() += move;
+    pp->GetActor()->spr.pos += move;
 
     if ((sop->flags & SOBJ_DONT_ROTATE))
     {

--- a/source/games/sw/src/track.cpp
+++ b/source/games/sw/src/track.cpp
@@ -844,7 +844,7 @@ void SectorObjectSetupBounds(SECTOR_OBJECT* sop)
                 }
 
 
-                itActor->user.pos.XY() = sop->pmid.XY() - itActor->spr.pos.XY();
+                itActor->user.pos.SetXY(sop->pmid.XY() - itActor->spr.pos.XY());
                 itActor->user.pos.Z = sop->mid_sector->floorz - itActor->spr.pos.Z;
 
                 itActor->user.Flags |= (SPR_SO_ATTACHED);
@@ -1481,7 +1481,7 @@ void MovePlayer(DSWPlayer* pp, SECTOR_OBJECT* sop, const DVector2& move)
         pp->Flags |= (PF_PLAYER_RIDING);
 
         pp->RevolveAng = pp->GetActor()->spr.Angles.Yaw;
-        pp->Revolve.XY() = pp->GetActor()->spr.pos.XY();
+        pp->Revolve.SetXY(pp->GetActor()->spr.pos.XY());
 
         // set the delta angle to 0 when moving
         pp->RevolveDeltaAng = nullAngle;
@@ -1503,7 +1503,7 @@ void MovePlayer(DSWPlayer* pp, SECTOR_OBJECT* sop, const DVector2& move)
         // moving then you
         // know where he was last
         pp->RevolveAng = pp->GetActor()->spr.Angles.Yaw;
-        pp->Revolve.XY() = pp->GetActor()->spr.pos.XY();
+        pp->Revolve.SetXY(pp->GetActor()->spr.pos.XY());
 
         // set the delta angle to 0 when moving
         pp->RevolveDeltaAng = nullAngle;
@@ -1522,7 +1522,7 @@ void MovePlayer(DSWPlayer* pp, SECTOR_OBJECT* sop, const DVector2& move)
     // increment Players delta angle
     pp->RevolveDeltaAng += GlobSpeedSO;
 
-    pp->GetActor()->spr.pos.XY() = rotatepoint(sop->pmid.XY(), pp->Revolve.XY(), pp->RevolveDeltaAng);
+    pp->GetActor()->spr.pos.SetXY(rotatepoint(sop->pmid.XY(), pp->Revolve.XY(), pp->RevolveDeltaAng));
 
     // THIS WAS CAUSING PROLEMS!!!!
     // Sectors are still being manipulated so you can end up in a void (-1) sector
@@ -1554,7 +1554,7 @@ void MovePoints(SECTOR_OBJECT* sop, DAngle deltaangle, const DVector2& move)
         PlayerMove = false;
 
     // move child sprite along also
-    sop->sp_child->spr.pos.XY() = sop->pmid.XY();
+    sop->sp_child->spr.pos.SetXY(sop->pmid.XY());
 
     // setting floor z if need be
     if ((sop->flags & SOBJ_ZMID_FLOOR))
@@ -1652,7 +1652,7 @@ PlayerPart:
             }
         }
 
-        actor->spr.pos.XY() = sop->pmid.XY() - actor->user.pos.XY();
+        actor->spr.pos.SetXY(sop->pmid.XY() - actor->user.pos.XY());
 
         // sprites z update
         if ((sop->flags & SOBJ_SPRITE_OBJ))
@@ -1690,12 +1690,12 @@ PlayerPart:
 
             if ((actor->sector()->walls[0].extra & WALLFX_LOOP_REVERSE_SPIN))
             {
-                actor->spr.pos.XY() = rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), -deltaangle);
+                actor->spr.pos.SetXY(rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), -deltaangle));
                 actor->spr.Angles.Yaw -= deltaangle;
             }
             else
             {
-                actor->spr.pos.XY() = rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), deltaangle);
+                actor->spr.pos.SetXY(rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), deltaangle));
                 actor->spr.Angles.Yaw += deltaangle;
             }
 			actor->norm_ang();
@@ -1705,7 +1705,7 @@ PlayerPart:
             if (!(sop->flags & SOBJ_DONT_ROTATE))
             {
                 // NOT part of a sector - independant of any sector
-                actor->spr.pos.XY() = rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), deltaangle);
+                actor->spr.pos.SetXY(rotatepoint(sop->pmid.XY(), actor->spr.pos.XY(), deltaangle));
                 actor->spr.Angles.Yaw += deltaangle;
 				actor->norm_ang();
             }
@@ -3240,7 +3240,7 @@ bool ActorTrackDecide(TRACK_POINT* tpoint, DSWActor* actor)
             // move out in front of the ladder
             auto vec = lActor->spr.Angles.Yaw.ToVector() * 6.25;
 
-			actor->spr.pos.XY() = lActor->spr.pos.XY() + vec;
+			actor->spr.pos.SetXY(lActor->spr.pos.XY() + vec);
 
 			actor->spr.Angles.Yaw += DAngle180;
 
@@ -3446,7 +3446,7 @@ int ActorFollowTrack(DSWActor* actor, short locktics)
         else
         {
             // calculate a new x and y
-			vec.XY() = actor->spr.Angles.Yaw.ToVector() * actor->vel.X;
+			vec.SetXY(actor->spr.Angles.Yaw.ToVector() * actor->vel.X);
         }
 
         if (actor->vel.Z != 0)

--- a/source/games/sw/src/weapon.cpp
+++ b/source/games/sw/src/weapon.cpp
@@ -3832,7 +3832,7 @@ int DoVomit(DSWActor* actor)
         actor->spr.pos.Z = actor->user.loz;
         actor->user.WaitTics = 60;
         // notreallypos
-        actor->user.pos.XY() = actor->spr.scale;
+        actor->user.pos.SetXY(actor->spr.scale);
         return 0;
     }
 
@@ -4061,14 +4061,14 @@ int SpawnBlood(DSWActor* actor, DSWActor* weapActor, DAngle hit_angle, const DVe
             {
                 p = ExtraBlood;
                 hit_angle = weapActor->spr.Angles.Yaw + DAngle180;
-                hitpos.XY() = actor->spr.pos.XY();
+                hitpos.SetXY(actor->spr.pos.XY());
                 hitpos.Z = ActorZOfTop(weapActor) + (ActorSizeZ(weapActor) * 0.25);
             }
             break;
         case SERP_RUN_R0:
             p = ExtraBlood;
             hit_angle = weapActor->spr.Angles.Yaw + DAngle180;
-            hitpos.XY() = actor->spr.pos.XY();
+            hitpos.SetXY(actor->spr.pos.XY());
             hitpos.Z = ActorZOfTop(actor) + (ActorSizeZ(actor) * 0.25);
             break;
         case BLADE1:
@@ -4077,26 +4077,26 @@ int SpawnBlood(DSWActor* actor, DSWActor* weapActor, DAngle hit_angle, const DVe
         case 5011:
             p = SmallBlood;
             hit_angle = AngToSprite(actor, weapActor) + DAngle180;
-            hitpos.XY() = actor->spr.pos.XY();
+            hitpos.SetXY(actor->spr.pos.XY());
             hitpos.Z = weapActor->spr.pos.Z + (ActorSizeZ(weapActor) * 0.5);
             break;
         case STAR1:
         case CROSSBOLT:
             p = SomeBlood;
             hit_angle = weapActor->spr.Angles.Yaw + DAngle180;
-            hitpos.XY() = actor->spr.pos.XY();
+            hitpos.SetXY(actor->spr.pos.XY());
             hitpos.Z = weapActor->spr.pos.Z;
             break;
         case PLASMA_FOUNTAIN:
             p = PlasmaFountainBlood;
             hit_angle = weapActor->spr.Angles.Yaw;
-            hitpos.XY() = actor->spr.pos.XY();
+            hitpos.SetXY(actor->spr.pos.XY());
             hitpos.Z = ActorZOfTop(actor) + (ActorSizeZ(actor) * 0.25);
             break;
         default:
             p = SomeBlood;
             hit_angle = weapActor->spr.Angles.Yaw + DAngle180;
-            hitpos.XY() = actor->spr.pos.XY();
+            hitpos.SetXY(actor->spr.pos.XY());
             hitpos.Z = ActorZOfTop(weapActor) + (ActorSizeZ(weapActor) * 0.25);
             break;
         }
@@ -8272,7 +8272,7 @@ void WallBounce(DSWActor* actor, DAngle ang)
     //
 	if (old_ang == actor->spr.Angles.Yaw)
     {
-        actor->user.change.XY() = -actor->user.change.XY();
+        actor->user.change.SetXY(-actor->user.change.XY());
 		SetAngleFromChange(actor);
     }
 }
@@ -10284,7 +10284,7 @@ void SpawnNuclearSecondaryExp(DSWActor* actor, DAngle ang)
 
     //ang = RANDOM_P2(2048);
     double const vel = (128+8) + RandomRangeF(128);
-    expActor->user.change.XY() = ang.ToVector() * vel;
+    expActor->user.change.SetXY(ang.ToVector() * vel);
     expActor->user.Radius = 200; // was NUKE_RADIUS
     expActor->user.coll = move_missile(expActor, DVector3(expActor->user.change.XY(), 0),
 									   expActor->user.ceiling_dist,expActor->user.floor_dist, CLIPMASK_MISSILE, MISSILEMOVETICS);
@@ -10481,7 +10481,7 @@ void AddSpriteToSectorObject(DSWActor* actor, SECTOR_OBJECT* sop)
 
     actor->user.Flags |= (SPR_ON_SO_SECTOR|SPR_SO_ATTACHED);
 
-    actor->user.pos.XY() = sop->pmid.XY() - actor->spr.pos.XY();
+    actor->user.pos.SetXY(sop->pmid.XY() - actor->spr.pos.XY());
     actor->user.pos.Z = sop->mid_sector->floorz - actor->spr.pos.Z;
 
     actor->user.sang = actor->spr.Angles.Yaw;
@@ -10571,7 +10571,7 @@ void SpawnGrenadeSecondaryExp(DSWActor* actor, DAngle ang)
 
     //ang = RANDOM_P2(2048);
     double vel = (96) + RandomRangeF(64);
-    expActor->user.change.XY() = ang.ToVector() * vel;
+    expActor->user.change.SetXY(ang.ToVector() * vel);
 
     expActor->user.coll = move_missile(expActor, DVector3(expActor->user.change.XY(), 0),
                            expActor->user.ceiling_dist,expActor->user.floor_dist, CLIPMASK_MISSILE, MISSILEMOVETICS);
@@ -11168,7 +11168,7 @@ int DoBloodWorm(DSWActor* actor)
 
     if (actor->user.coll.type != kHitNone)
     {
-		actor->user.change.XY() = -actor->user.change.XY();
+		actor->user.change.SetXY(-actor->user.change.XY());
         actor->user.coll.setNone();
         actor->spr.Angles.Yaw += DAngle180;
         return true;
@@ -11222,7 +11222,7 @@ int DoBloodWorm(DSWActor* actor)
         GlobalSkipZrange = false;
     }
 
-	actor->spr.pos.XY() = bpos;
+	actor->spr.pos.SetXY(bpos);
 
     return false;
 }
@@ -17011,7 +17011,7 @@ int InitEnemyFireball(DSWActor* actor)
         HelpMissileLateral(actorNew, 500);
         actorNew->spr.Angles.Yaw -= lat_ang[i];
 
-        actorNew->user.change.XY() = change;
+        actorNew->user.change.SetXY(change);
 
         MissileSetPos(actorNew, DoFireball, 700);
 
@@ -17097,7 +17097,7 @@ bool WarpToUnderwater(DVector3& pos, sectortype** psectu)
 	spos = overActor->spr.pos.XY() - pos.XY();
 
     // update to the new x y position
-	pos.XY() = underActor->spr.pos.XY() - spos;
+	pos.SetXY(underActor->spr.pos.XY() - spos);
 
     auto over = overActor->sector();
     auto under = underActor->sector();
@@ -17169,7 +17169,7 @@ bool WarpToSurface(DVector3& pos, sectortype** psectu)
 	DVector2 spos = underActor->spr.pos.XY() - pos.XY();
 
     // update to the new x y position
-    pos.XY() = overActor->spr.pos.XY() - spos;
+    pos.SetXY(overActor->spr.pos.XY() - spos);
 
     auto over = overActor->sector();
     auto under = underActor->sector();
@@ -17472,7 +17472,7 @@ DSWActor* SpawnBubble(DSWActor* actor)
     double scale = (8 + (RANDOM_P2(8 << 8) >> 8)) * REPEAT_SCALE;
     actorNew->spr.scale = DVector2(scale, scale);
     // notreallypos
-    actorNew->user.pos.XY() = actorNew->spr.scale;
+    actorNew->user.pos.SetXY(actorNew->spr.scale);
     actorNew->user.ceiling_dist = 1;
     actorNew->user.floor_dist = 1;
     actorNew->spr.shade = actor->sector()->floorshade - 10;
@@ -18695,7 +18695,7 @@ int DoItemFly(DSWActor* actor)
             }
             else
             {
-				actor->user.change.XY() = -actor->user.change.XY();
+				actor->user.change.SetXY(-actor->user.change.XY());
             }
 
             break;

--- a/source/games/sw/src/weapon.cpp
+++ b/source/games/sw/src/weapon.cpp
@@ -17235,7 +17235,7 @@ bool SpriteWarpToUnderwater(DSWActor* actor)
     ASSERT(Found);
 
     // update to the new x y position
-	actor->spr.pos.XY() += (underActor->spr.pos.XY() - overActor->spr.pos.XY());
+	actor->spr.pos += (underActor->spr.pos.XY() - overActor->spr.pos.XY());
 
     auto over = overActor->sector();
     auto under = underActor->sector();
@@ -17494,7 +17494,7 @@ DSWActor* SpawnBubble(DSWActor* actor)
 
 int DoVehicleSmoke(DSWActor* actor)
 {
-	actor->spr.pos.XY() += actor->user.change.XY();
+	actor->spr.pos += actor->user.change.XY();
     actor->spr.pos.Z -= actor->vel.Z;
     return false;
 }


### PR DESCRIPTION
Fixes #1141.

The commit 940e53af6fed5ed9f50f5495eac9d1fda42a6065 seems to have broken all horizontal movement in Raze. The commit copied a change to `vectors.h` from GZDoom that makes it so `TVector3::XY()` returns a fresh TVector2 object instead of a reference to the TVector3 type-punned to look like a TVector2, which has the consequence that modifying the returned object (like `vec3.XY() = someVec2;`) no longer works to modify the TVector3. That wasn't an issue in GZDoom but this pattern is done in a ton of places in Raze.

The commit changed `vectors.h` to no longer use type-punning which seems like a reasonable goal, so I wanted to find a solution that didn't just revert that. I think it would be possible to make all of Raze's code continue working by making the `TVector3::XY()` method return a TVector2-like proxy object that contains references to the TVector3's X and Y properties and implements all of the same methods as TVector2 and support for being implicitly converted to a TVector2, but that struck me as a lot of duplication in `vectors.h` which also wouldn't be useful for GZDoom. Instead I just went through all of the calls to `TVector3::XY()` that mutated the returned value and made them not do that.

Here are the main kinds of changes I did many times:

```diff
-spr.pos.XY() = opos.XY();
+spr.pos.SetXY(opos.XY());
```

I added a `TVector3::SetXY(const Vector2 &v)` method instead of overloading `operator=` for Vector2 values because it seemed like the latter might allow accidents.

```diff
-pPlayerActor->vel.XY().Zero();
+pPlayerActor->vel.SetXY(DVector2(0, 0));
```

```diff
-tspr->pos.XY() += tspr->Angles.Yaw.ToVector() * 0.125;
+tspr->pos += tspr->Angles.Yaw.ToVector() * 0.125;
```

The above works because TVector3 has methods like `TVector3 &operator+= (const Vector2 &other)` and other compound assignment operators defined for it that only affects the X and Y properties.

```diff
-p->vel.XY() *= gs.playerfriction;
+p->vel.SetXY(p->vel.XY() * gs.playerfriction);
```

This had to be handled differently because `gs.playerfriction` is a number instead of a Vector2, so if I just removed the `.XY()` part again then all 3 coordinates would be modified, not just X and Y.

Additionally, while working on this I discovered a bug in `source/games/blood/src/aiunicult.cpp` `dudeLeechOperate()` where the Z coordinate of a vector wasn't set to the intended value and was left uninitialized. It's fixed in its own commit, 3ff9ef5f65b223276a3f06f2107ce614d84153c1.